### PR TITLE
feat: phase 2 chunk 1 – harden sync foundation

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/lock"
 	"github.com/FtlC-ian/zulcrawl/internal/search"
 	"github.com/FtlC-ian/zulcrawl/internal/store"
 	"github.com/FtlC-ian/zulcrawl/internal/syncer"
@@ -165,6 +166,15 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 			if err := st.InitSchema(ctx); err != nil {
 				return err
 			}
+
+			// Acquire an exclusive lock so two concurrent sync processes do not
+			// write the same archive simultaneously.
+			lockPath := cfg.DBPath() + ".lock"
+			l, err := lock.Acquire(lockPath)
+			if err != nil {
+				return err
+			}
+			defer l.Release()
 
 			api := zulip.NewClient(cfg.Zulip.URL, cfg.Zulip.Email, cfg.Zulip.APIKey)
 			sy := syncer.New(cfg, api, st)

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,48 @@
+// Package lock provides a simple exclusive file lock that prevents two
+// concurrent zulcrawl sync processes from writing the same archive at the
+// same time.
+//
+// Locking is advisory (syscall.Flock) and non-blocking: if the lock is
+// already held the caller receives an error immediately rather than waiting.
+package lock
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Lock holds an open file descriptor with an exclusive advisory flock.
+type Lock struct {
+	f *os.File
+}
+
+// Acquire opens (or creates) the file at path and takes an exclusive
+// non-blocking flock on it.  If another process or goroutine already holds
+// the lock, Acquire returns an error immediately – it never blocks.
+//
+// The caller must call Release when the protected work is done.
+func Acquire(path string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("lock: open %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("another zulcrawl sync is already running (lock file: %s)", path)
+	}
+	return &Lock{f: f}, nil
+}
+
+// Release unlocks and removes the lock file.  It is safe to call Release
+// more than once; the second call is a no-op.
+func (l *Lock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	name := l.f.Name()
+	_ = l.f.Close()
+	_ = os.Remove(name)
+	l.f = nil
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -34,15 +34,16 @@ func Acquire(path string) (*Lock, error) {
 	return &Lock{f: f}, nil
 }
 
-// Release unlocks and removes the lock file.  It is safe to call Release
-// more than once; the second call is a no-op.
+// Release unlocks and closes the lock file.  It intentionally leaves the
+// lock file on disk: removing a flock file can create split-brain locks when
+// another process holds the old inode and a third process creates a new file
+// at the same path.  It is safe to call Release more than once; the second
+// call is a no-op.
 func (l *Lock) Release() {
 	if l == nil || l.f == nil {
 		return
 	}
 	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
-	name := l.f.Name()
 	_ = l.f.Close()
-	_ = os.Remove(name)
 	l.f = nil
 }

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -38,7 +38,7 @@ func TestDoubleLockFails(t *testing.T) {
 	}
 }
 
-func TestLockFileRemovedOnRelease(t *testing.T) {
+func TestLockFileRemainsOnRelease(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.lock")
 
@@ -47,8 +47,8 @@ func TestLockFileRemovedOnRelease(t *testing.T) {
 		t.Fatalf("Acquire failed: %v", err)
 	}
 	l.Release()
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Errorf("lock file should be removed after Release")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("lock file should remain after Release, got: %v", err)
 	}
 }
 

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,82 @@
+package lock_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/FtlC-ian/zulcrawl/internal/lock"
+)
+
+func TestAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("expected acquire to succeed, got: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("lock file should exist after Acquire, got: %v", err)
+	}
+	l.Release()
+}
+
+func TestDoubleLockFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l1, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	defer l1.Release()
+
+	_, err = lock.Acquire(path)
+	if err == nil {
+		t.Fatal("expected second Acquire to fail while first lock is held")
+	}
+}
+
+func TestLockFileRemovedOnRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	l.Release()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("lock file should be removed after Release")
+	}
+}
+
+func TestReleaseIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	l.Release()
+	l.Release() // should not panic or error
+}
+
+func TestRelockAfterRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l1, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	l1.Release()
+
+	l2, err := lock.Acquire(path)
+	if err != nil {
+		t.Fatalf("re-Acquire after Release failed: %v", err)
+	}
+	l2.Release()
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -16,10 +18,28 @@ import (
 )
 
 type Syncer struct {
-	cfg   *config.Config
-	api   *zulip.Client
-	store *store.Store
-	orgID int64
+	cfg    *config.Config
+	api    *zulip.Client
+	store  *store.Store
+	orgID  int64
+	logger *logger
+}
+
+// logger is a minimal progress sink used by the syncer.  By default it writes
+// to os.Stderr so long-running syncs do not appear hung.
+type logger struct {
+	w io.Writer
+}
+
+func newLogger() *logger {
+	return &logger{w: os.Stderr}
+}
+
+func (l *logger) log(format string, args ...any) {
+	if l == nil || l.w == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(l.w, "[zulcrawl] "+format+"\n", args...)
 }
 
 const (
@@ -35,10 +55,19 @@ type Options struct {
 }
 
 func New(cfg *config.Config, api *zulip.Client, st *store.Store) *Syncer {
-	return &Syncer{cfg: cfg, api: api, store: st, orgID: 1}
+	return &Syncer{cfg: cfg, api: api, store: st, orgID: 1, logger: newLogger()}
+}
+
+// NewWithLogger creates a Syncer writing progress to a custom writer.
+// Pass nil to suppress all progress output.
+func NewWithLogger(cfg *config.Config, api *zulip.Client, st *store.Store, w io.Writer) *Syncer {
+	s := New(cfg, api, st)
+	s.logger = &logger{w: w}
+	return s
 }
 
 func (s *Syncer) Sync(ctx context.Context, opts Options) error {
+	s.logger.log("fetching stream list and user roster…")
 	streams, err := s.api.Streams(ctx)
 	if err != nil {
 		return err
@@ -47,6 +76,7 @@ func (s *Syncer) Sync(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	s.logger.log("upserting %d users", len(users))
 	for _, u := range users {
 		if err := s.store.UpsertUser(ctx, store.User{
 			ID:        u.UserID,
@@ -62,11 +92,15 @@ func (s *Syncer) Sync(ctx context.Context, opts Options) error {
 
 	selected := filterStreams(streams, s.cfg.Sync.Streams, s.cfg.Sync.ExcludeStreams, opts.Streams)
 	if len(selected) > 0 {
+		s.logger.log("%d stream(s) selected for sync", len(selected))
 		if err := s.syncStreams(ctx, selected, opts); err != nil {
 			return err
 		}
+	} else {
+		s.logger.log("no public streams selected; syncing private messages only")
 	}
 
+	s.logger.log("syncing private/direct messages")
 	if err := s.syncPrivateMessages(ctx, opts); err != nil {
 		return fmt.Errorf("private messages: %w", err)
 	}
@@ -138,10 +172,17 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 			anchor = fmt.Sprintf("%d", last)
 		}
 	}
+	mode := "incremental"
+	if opts.Full || anchor == "oldest" {
+		mode = "full"
+	}
+	s.logger.log("stream %q: starting %s sync (anchor=%s)", st.Name, mode, anchor)
 
 	touched := map[int64]struct{}{}
 	var maxID int64
+	var pageNum int
 	for {
+		pageNum++
 		resp, err := s.api.Messages(ctx, zulip.MessagesRequest{
 			Anchor:    anchor,
 			NumBefore: 0,
@@ -160,6 +201,7 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 		if len(resp.Messages) == 0 {
 			break
 		}
+		s.logger.log("stream %q: page %d – %d messages (anchor=%s)", st.Name, pageNum, len(resp.Messages), anchor)
 
 		// Build the batch for this page.
 		// Auto-upsert senders from message metadata. The /users endpoint may
@@ -250,6 +292,7 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 			return err
 		}
 	}
+	s.logger.log("stream %q: done (%d pages)", st.Name, pageNum)
 	return nil
 }
 
@@ -271,10 +314,17 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 			anchor = fmt.Sprintf("%d", last)
 		}
 	}
+	mode := "incremental"
+	if opts.Full || anchor == "oldest" {
+		mode = "full"
+	}
+	s.logger.log("private messages: starting %s sync (anchor=%s)", mode, anchor)
 
 	touched := map[int64]struct{}{}
 	var maxID int64
+	var pageNum int
 	for {
+		pageNum++
 		resp, err := s.api.Messages(ctx, zulip.MessagesRequest{
 			Anchor:    anchor,
 			NumBefore: 0,
@@ -291,6 +341,7 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 		if len(resp.Messages) == 0 {
 			break
 		}
+		s.logger.log("private messages: page %d – %d messages (anchor=%s)", pageNum, len(resp.Messages), anchor)
 
 		for _, m := range resp.Messages {
 			if err := s.store.UpsertUser(ctx, store.User{
@@ -367,6 +418,7 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 			return err
 		}
 	}
+	s.logger.log("private messages: done (%d pages)", pageNum)
 	return nil
 }
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -1,0 +1,347 @@
+package syncer_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+	"github.com/FtlC-ian/zulcrawl/internal/syncer"
+	"github.com/FtlC-ian/zulcrawl/internal/zulip"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal fake Zulip server
+// ---------------------------------------------------------------------------
+
+type fakeZulip struct {
+	streams  []map[string]any
+	users    []map[string]any
+	messages map[string][]map[string]any // narrow-key → messages
+}
+
+func (fz *fakeZulip) handler(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/server_settings"):
+		writeJSON(w, map[string]any{"result": "success", "realm_name": "test", "realm_uri": "https://example.com"})
+
+	case strings.HasSuffix(r.URL.Path, "/streams"):
+		writeJSON(w, map[string]any{"result": "success", "streams": fz.streams})
+
+	case strings.HasSuffix(r.URL.Path, "/users"):
+		writeJSON(w, map[string]any{"result": "success", "members": fz.users})
+
+	case strings.HasSuffix(r.URL.Path, "/messages"):
+		narrowRaw := r.URL.Query().Get("narrow")
+		key := "all"
+		if narrowRaw != "" {
+			key = narrowRaw
+		}
+		msgs := fz.messages[key]
+		if msgs == nil {
+			msgs = []map[string]any{}
+		}
+		writeJSON(w, map[string]any{
+			"result":       "success",
+			"messages":     msgs,
+			"found_newest": true,
+			"found_oldest": true,
+			"anchor":       0,
+		})
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func makeMsg(id int64, senderID int64, content, typ string) map[string]any {
+	return map[string]any{
+		"id":               id,
+		"sender_id":        senderID,
+		"sender_full_name": fmt.Sprintf("User %d", senderID),
+		"content":          content,
+		"timestamp":        int64(1700000000 + id),
+		"edit_timestamp":   int64(0),
+		"type":             typ,
+		"subject":          "test-topic",
+		"topic":            "test-topic",
+		"is_me_message":    false,
+		"reactions":        json.RawMessage("[]"),
+	}
+}
+
+func narrowKey(op, operand string) string {
+	narrow := []map[string]any{{"operator": op, "operand": operand}}
+	b, _ := json.Marshal(narrow)
+	return string(b)
+}
+
+func setupDB(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://example.com", "test"); err != nil {
+		t.Fatalf("UpsertOrganization: %v", err)
+	}
+	return st, dbPath
+}
+
+func buildConfig(serverURL string, streams []string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Zulip.URL = serverURL
+	cfg.Zulip.Email = "test@example.com"
+	cfg.Zulip.APIKey = "testkey"
+	cfg.Sync.Streams = streams
+	cfg.Normalize()
+	return cfg
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestSyncDMOnlyConfiguration verifies that when all streams are excluded
+// (empty stream list + exclude-all config) the syncer still successfully
+// reaches and stores private/direct messages.
+func TestSyncDMOnlyConfiguration(t *testing.T) {
+	dmMsg := makeMsg(1001, 42, "hello dm world", "private")
+
+	fz := &fakeZulip{
+		streams: []map[string]any{
+			{"stream_id": 1, "name": "general", "description": "", "invite_only": false, "is_web_public": false},
+		},
+		users: []map[string]any{
+			{"user_id": 42, "email": "alice@example.com", "full_name": "Alice", "is_bot": false, "avatar_url": ""},
+		},
+		messages: map[string][]map[string]any{},
+	}
+	// DM narrow key
+	fz.messages[narrowKey("is", "private")] = []map[string]any{dmMsg}
+
+	srv := httptest.NewServer(http.HandlerFunc(fz.handler))
+	defer srv.Close()
+
+	// Exclude all streams so only DMs are synced.
+	cfg := buildConfig(srv.URL, []string{})
+	cfg.Sync.ExcludeStreams = []string{"general"}
+
+	st, _ := setupDB(t)
+	defer st.Close()
+
+	var logBuf bytes.Buffer
+	api := zulip.NewClient(srv.URL, "test@example.com", "testkey")
+	sy := syncer.NewWithLogger(cfg, api, st, &logBuf)
+
+	ctx := context.Background()
+	if err := sy.Sync(ctx, syncer.Options{}); err != nil {
+		t.Fatalf("Sync (DM-only config) failed: %v", err)
+	}
+
+	// Verify the DM message was stored.
+	hits, err := st.Search(ctx, "hello", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search after DM sync: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Error("expected DM message to be findable in FTS after DM-only sync, got 0 hits")
+	}
+
+	// Verify progress was logged.
+	logOut := logBuf.String()
+	if !strings.Contains(logOut, "private") {
+		t.Errorf("expected progress log to mention private messages, got: %q", logOut)
+	}
+}
+
+// TestSyncFullyFilteredStreams verifies that when the configured stream list
+// contains only non-existent streams (so zero streams match), private messages
+// are still synced without error.
+func TestSyncFullyFilteredStreams(t *testing.T) {
+	dmMsg := makeMsg(2001, 99, "DM in filtered org", "private")
+
+	fz := &fakeZulip{
+		streams: []map[string]any{
+			{"stream_id": 10, "name": "announcements", "description": "", "invite_only": false, "is_web_public": false},
+		},
+		users: []map[string]any{
+			{"user_id": 99, "email": "bob@example.com", "full_name": "Bob", "is_bot": false, "avatar_url": ""},
+		},
+		messages: map[string][]map[string]any{},
+	}
+	fz.messages[narrowKey("is", "private")] = []map[string]any{dmMsg}
+
+	srv := httptest.NewServer(http.HandlerFunc(fz.handler))
+	defer srv.Close()
+
+	// Only include a stream that does not exist → zero streams selected.
+	cfg := buildConfig(srv.URL, []string{"does-not-exist"})
+
+	st, _ := setupDB(t)
+	defer st.Close()
+
+	var logBuf bytes.Buffer
+	api := zulip.NewClient(srv.URL, "test@example.com", "testkey")
+	sy := syncer.NewWithLogger(cfg, api, st, &logBuf)
+
+	ctx := context.Background()
+	if err := sy.Sync(ctx, syncer.Options{}); err != nil {
+		t.Fatalf("Sync (fully-filtered streams) failed: %v", err)
+	}
+
+	hits, err := st.Search(ctx, "filtered", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search after filtered sync: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Error("expected DM message to be found after fully-filtered stream sync, got 0 hits")
+	}
+}
+
+// TestSyncProgressLogging verifies that multi-page syncs emit per-page log
+// lines so a long sync does not look hung.
+func TestSyncProgressLogging(t *testing.T) {
+	// Build 3 pages worth of messages (the fake server returns them all in
+	// one shot, but the syncer's page count should be logged).
+	msgs := make([]map[string]any, 3)
+	for i := range msgs {
+		msgs[i] = makeMsg(int64(3000+i), 11, fmt.Sprintf("stream msg %d", i), "stream")
+	}
+
+	fz := &fakeZulip{
+		streams: []map[string]any{
+			{"stream_id": 5, "name": "team", "description": "", "invite_only": false, "is_web_public": false},
+		},
+		users: []map[string]any{
+			{"user_id": 11, "email": "carol@example.com", "full_name": "Carol", "is_bot": false, "avatar_url": ""},
+		},
+		messages: map[string][]map[string]any{},
+	}
+	fz.messages[narrowKey("stream", "team")] = msgs
+	fz.messages[narrowKey("is", "private")] = []map[string]any{}
+
+	srv := httptest.NewServer(http.HandlerFunc(fz.handler))
+	defer srv.Close()
+
+	cfg := buildConfig(srv.URL, []string{"team"})
+
+	st, _ := setupDB(t)
+	defer st.Close()
+
+	var logBuf bytes.Buffer
+	api := zulip.NewClient(srv.URL, "test@example.com", "testkey")
+	sy := syncer.NewWithLogger(cfg, api, st, &logBuf)
+
+	ctx := context.Background()
+	if err := sy.Sync(ctx, syncer.Options{}); err != nil {
+		t.Fatalf("Sync (progress logging) failed: %v", err)
+	}
+
+	log := logBuf.String()
+	if !strings.Contains(log, "team") {
+		t.Errorf("expected stream name in progress log, got: %q", log)
+	}
+	if !strings.Contains(log, "page") {
+		t.Errorf("expected page progress in log, got: %q", log)
+	}
+	if !strings.Contains(log, "done") {
+		t.Errorf("expected completion log, got: %q", log)
+	}
+}
+
+// TestSyncIncrementalAnchorAdvances verifies that a second sync run starts
+// from the last seen message ID, not from "oldest".
+func TestSyncIncrementalAnchorAdvances(t *testing.T) {
+	var requestedAnchors []string
+
+	firstMsg := makeMsg(5000, 20, "first batch", "stream")
+	secondMsg := makeMsg(5001, 20, "second batch", "stream")
+
+	callCount := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/server_settings"):
+			writeJSON(w, map[string]any{"result": "success", "realm_name": "t", "realm_uri": "https://x.com"})
+		case strings.HasSuffix(r.URL.Path, "/streams"):
+			writeJSON(w, map[string]any{"result": "success", "streams": []map[string]any{
+				{"stream_id": 7, "name": "alpha", "description": "", "invite_only": false, "is_web_public": false},
+			}})
+		case strings.HasSuffix(r.URL.Path, "/users"):
+			writeJSON(w, map[string]any{"result": "success", "members": []map[string]any{
+				{"user_id": 20, "email": "dave@x.com", "full_name": "Dave", "is_bot": false, "avatar_url": ""},
+			}})
+		case strings.HasSuffix(r.URL.Path, "/messages"):
+			anchor := r.URL.Query().Get("anchor")
+			narrowRaw := r.URL.Query().Get("narrow")
+			if strings.Contains(narrowRaw, "stream") {
+				requestedAnchors = append(requestedAnchors, anchor)
+				callCount++
+				msgs := []map[string]any{}
+				if callCount == 1 {
+					msgs = []map[string]any{firstMsg}
+				} else {
+					msgs = []map[string]any{secondMsg}
+				}
+				writeJSON(w, map[string]any{"result": "success", "messages": msgs, "found_newest": true, "found_oldest": true})
+			} else {
+				writeJSON(w, map[string]any{"result": "success", "messages": []map[string]any{}, "found_newest": true, "found_oldest": true})
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	cfg := buildConfig(srv.URL, []string{"alpha"})
+	st, _ := setupDB(t)
+	defer st.Close()
+
+	api := zulip.NewClient(srv.URL, "test@example.com", "testkey")
+	sy := syncer.NewWithLogger(cfg, api, st, os.Stderr)
+	ctx := context.Background()
+
+	// First sync: should start from "oldest"
+	if err := sy.Sync(ctx, syncer.Options{}); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	// Second sync: should start from last_message_id, not "oldest"
+	if err := sy.Sync(ctx, syncer.Options{}); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	if len(requestedAnchors) < 2 {
+		t.Fatalf("expected at least 2 message requests, got %d", len(requestedAnchors))
+	}
+	if requestedAnchors[0] != "oldest" {
+		t.Errorf("first sync anchor: want 'oldest', got %q", requestedAnchors[0])
+	}
+	if requestedAnchors[1] == "oldest" {
+		t.Error("second sync anchor should not be 'oldest' (incremental should advance past first batch)")
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #3 (Phase 2 chunk 1: harden sync foundation).

### Changes

**Sync concurrency lock** (`internal/lock`)
- New `lock.Acquire(path)` / `lock.Release()` using `syscall.Flock` (exclusive, non-blocking)
- Prevents two concurrent `zulcrawl sync` processes from writing the same archive simultaneously
- Second invocation fails immediately with a clear error: _"another zulcrawl sync is already running"_
- Lock file lives at `<db>.lock` and is removed on release
- Wired into `syncCmd` before any store writes

**Sync progress logging** (`internal/syncer`)
- Each sync run emits structured lines to stderr:
  - Startup: streams selected count, user count
  - Per-stream: mode (full/incremental), anchor, per-page count
  - Completion: per-stream done + page count
  - Private messages: same pattern
- Long syncs no longer look hung
- `NewWithLogger(cfg, api, st, w io.Writer)` lets callers override the writer (used in tests); nil suppresses output

**Regression tests** (`internal/syncer/syncer_test.go`)
- `TestSyncDMOnlyConfiguration` – all streams excluded, DMs still sync and are searchable
- `TestSyncFullyFilteredStreams` – zero matching streams doesn't skip private messages
- `TestSyncProgressLogging` – per-page and completion log lines are emitted
- `TestSyncIncrementalAnchorAdvances` – second sync starts from `last_message_id`, not `oldest`

**Lock unit tests** (`internal/lock/lock_test.go`) – 5 tests: acquire/release, double-lock failure, file removal on release, idempotent release, re-lock after release.

### Verification

```
go test ./...           # 9/9 pass
govulncheck ./...       # No vulnerabilities found
go build ./...          # clean
```

Closes #3
