### PR TITLE
feat: phase 2 chunk 2 – add focused `messages` query command

### DIFF
--- a/internal/cli/messages_test.go
+++ b/internal/cli/messages_test.go
@@ -214,3 +214,32 @@ func TestMessagesCmd_All(t *testing.T) {
 
 // Verify config package is referenced (avoids unused import warning).
 var _ = config.DefaultPath
+
+func TestMessagesCommandNormalizesRFC3339Offsets(t *testing.T) {
+	cfgPath := setupCLITest(t)
+
+	out, err := runMessages(t, cfgPath, "--since", "2026-01-01T05:30:00-06:00", "--until", "2026-01-01T05:30:00-06:00")
+	if err != nil {
+		t.Fatalf("unexpected error for RFC3339 offset: %v", err)
+	}
+	if !strings.Contains(out, "No messages found") {
+		t.Errorf("expected normalized offset query to run and find no messages, got: %s", out)
+	}
+}
+
+func TestMessagesCommandRejectsNegativeCounts(t *testing.T) {
+	cfgPath := setupCLITest(t)
+
+	cases := [][]string{
+		{"--days", "-1"},
+		{"--hours", "-1"},
+		{"--last", "-1"},
+		{"--stream", "general", "--limit", "0"},
+	}
+	for _, tc := range cases {
+		_, err := runMessages(t, cfgPath, tc...)
+		if err == nil {
+			t.Fatalf("expected error for args %v", tc)
+		}
+	}
+}

--- a/internal/cli/messages_test.go
+++ b/internal/cli/messages_test.go
@@ -1,0 +1,216 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/FtlC-ian/zulcrawl/internal/cli"
+	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+// setupCLITest creates a config + seeded DB, returns a ready config path.
+func setupCLITest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+
+	// Write a minimal config.
+	cfgContent := "[zulip]\nurl = \"https://z.example.com\"\nemail = \"bot@example.com\"\napi_key = \"fakekey\"\n\n[database]\npath = \"" + dbPath + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the DB.
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://z.example.com", "TestOrg"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertStream(ctx, store.Stream{ID: 1, OrgID: 1, Name: "general"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertUser(ctx, store.User{ID: 10, OrgID: 1, FullName: "Alice"}); err != nil {
+		t.Fatal(err)
+	}
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 1, "deploys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	for i, content := range []string{"deployed v1", "deployed v2", "deployed v3"} {
+		if err := st.UpsertMessage(ctx, store.Message{
+			ID:          int64(100 + i),
+			OrgID:       1,
+			StreamID:    1,
+			TopicID:     topicID,
+			SenderID:    10,
+			Content:     content,
+			ContentText: content,
+			Timestamp:   now.Add(time.Duration(-3+i) * 24 * time.Hour).Format(time.RFC3339),
+		}); err != nil {
+			t.Fatalf("UpsertMessage: %v", err)
+		}
+	}
+	return cfgPath
+}
+
+func runMessages(t *testing.T, cfgPath string, args ...string) (string, error) {
+	t.Helper()
+	root := cli.NewRootCmd()
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	// Prepend --config and the sub-command.
+	fullArgs := append([]string{"--config", cfgPath, "messages"}, args...)
+	root.SetArgs(fullArgs)
+
+	err := root.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+// ---------------------------------------------------------------------------
+
+func TestMessagesCmd_RequiresFilter(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	_, err := runMessages(t, cfgPath) // no filters
+	if err == nil {
+		t.Fatal("expected error without filters, got nil")
+	}
+	if !strings.Contains(err.Error(), "narrowing filter") {
+		t.Errorf("error should mention narrowing filter, got: %v", err)
+	}
+}
+
+func TestMessagesCmd_ByStream(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--stream", "general")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nOutput: %s", err, out)
+	}
+	if !strings.Contains(out, "general") {
+		t.Errorf("expected 'general' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "deployed") {
+		t.Errorf("expected 'deployed' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "3 messages") {
+		t.Errorf("expected '3 messages' footer, got: %s", out)
+	}
+}
+
+func TestMessagesCmd_ByStreamAndTopic(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--stream", "general", "--topic", "deploys", "--days", "7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "deploys") {
+		t.Errorf("expected topic 'deploys' in output, got: %s", out)
+	}
+}
+
+func TestMessagesCmd_ByDays(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--days", "7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "deployed") {
+		t.Errorf("expected messages in output, got: %s", out)
+	}
+}
+
+func TestMessagesCmd_BySender(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--sender", "Alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Alice") {
+		t.Errorf("expected sender Alice in output, got: %s", out)
+	}
+}
+
+func TestMessagesCmd_InvalidSince(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	_, err := runMessages(t, cfgPath, "--since", "not-a-date")
+	if err == nil {
+		t.Fatal("expected error for invalid --since")
+	}
+}
+
+func TestMessagesCmd_ValidSinceRFC3339(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	since := time.Now().UTC().Add(-8 * 24 * time.Hour).Format(time.RFC3339)
+	out, err := runMessages(t, cfgPath, "--since", since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "deployed") {
+		t.Errorf("expected messages in output, got: %s", out)
+	}
+}
+
+func TestMessagesCmd_ValidSinceDate(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	since := time.Now().UTC().Add(-8 * 24 * time.Hour).Format("2006-01-02")
+	out, err := runMessages(t, cfgPath, "--since", since)
+	if err != nil {
+		t.Fatalf("unexpected error for YYYY-MM-DD --since: %v", err)
+	}
+	_ = out
+}
+
+func TestMessagesCmd_NoResults(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--stream", "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "No messages found") {
+		t.Errorf("expected 'No messages found', got: %s", out)
+	}
+}
+
+func TestMessagesCmd_Last(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--sender", "Alice", "--last", "2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "2 messages") {
+		t.Errorf("expected '2 messages', got: %s", out)
+	}
+}
+
+func TestMessagesCmd_All(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runMessages(t, cfgPath, "--stream", "general", "--all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "3 messages") {
+		t.Errorf("expected '3 messages', got: %s", out)
+	}
+}
+
+// Verify config package is referenced (avoids unused import warning).
+var _ = config.DefaultPath

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -382,27 +382,42 @@ The default safety limit is 200 messages; use --limit or --all to override.`,
 						"  Use --all to fetch the entire archive (may be very large)")
 			}
 
-			// Validate --since / --until formats.
+			if days < 0 {
+				return fmt.Errorf("--days must be positive")
+			}
+			if hours < 0 {
+				return fmt.Errorf("--hours must be positive")
+			}
+			if last < 0 {
+				return fmt.Errorf("--last must be positive")
+			}
+			if limit <= 0 && !all {
+				return fmt.Errorf("--limit must be positive unless --all is set")
+			}
+
+			// Validate --since / --until formats and normalize all values to the
+			// UTC RFC3339 strings stored in SQLite. Lexicographic comparisons only
+			// work correctly when equivalent instants use the same zone.
 			for flagName, val := range map[string]string{"since": since, "until": until} {
 				if val == "" {
 					continue
 				}
-				// Accept RFC3339 or YYYY-MM-DD.
-				if _, err := time.Parse(time.RFC3339, val); err != nil {
-					if _, err2 := time.Parse("2006-01-02", val); err2 != nil {
-						return fmt.Errorf("--%s must be RFC3339 (2006-01-02T15:04:05Z) or YYYY-MM-DD, got %q", flagName, val)
-					}
-					// Expand YYYY-MM-DD to start of day.
+				if t, err := time.Parse(time.RFC3339, val); err == nil {
 					if flagName == "since" {
-						since = val + "T00:00:00Z"
+						since = t.UTC().Format(time.RFC3339)
 					} else {
-						until = val + "T23:59:59Z"
+						until = t.UTC().Format(time.RFC3339)
 					}
+					continue
 				}
-			}
-
-			if all {
-				limit = 0 // 0 = no cap (store uses 0 to mean "no override")
+				if _, err := time.Parse("2006-01-02", val); err != nil {
+					return fmt.Errorf("--%s must be RFC3339 (2006-01-02T15:04:05Z) or YYYY-MM-DD, got %q", flagName, val)
+				}
+				if flagName == "since" {
+					since = val + "T00:00:00Z"
+				} else {
+					until = val + "T23:59:59Z"
+				}
 			}
 
 			f := store.MessagesFilter{
@@ -507,5 +522,3 @@ func flatString(m map[string]any, keys ...string) string {
 	}
 	return ""
 }
-
-

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(topicsCmd(loadCfg))
 	root.AddCommand(statsCmd(loadCfg))
 	root.AddCommand(sqlCmd(loadCfg))
+	root.AddCommand(messagesCmd(loadCfg))
 	return root
 }
 
@@ -345,6 +346,112 @@ func sqlCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 			return rows.Err()
 		},
 	}
+}
+
+func messagesCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var stream, topic, sender, since, until string
+	var days, hours, last, limit int
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "messages",
+		Short: "Query archived messages from the local SQLite DB",
+		Long: `Return an exact archive slice from the local SQLite database.
+
+At least one narrowing filter is required to avoid accidental full-archive
+dumps. Use --stream, --topic, --sender, --days, --hours, --since, or --until.
+The default safety limit is 200 messages; use --limit or --all to override.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+
+			// Require at least one narrowing filter.
+			if stream == "" && topic == "" && sender == "" &&
+				since == "" && until == "" && days == 0 && hours == 0 &&
+				last == 0 && !all {
+				return fmt.Errorf(
+					"at least one narrowing filter is required\n" +
+						"  e.g. --stream general --days 7\n" +
+						"  Use --all to fetch the entire archive (may be very large)")
+			}
+
+			// Validate --since / --until formats.
+			for flagName, val := range map[string]string{"since": since, "until": until} {
+				if val == "" {
+					continue
+				}
+				// Accept RFC3339 or YYYY-MM-DD.
+				if _, err := time.Parse(time.RFC3339, val); err != nil {
+					if _, err2 := time.Parse("2006-01-02", val); err2 != nil {
+						return fmt.Errorf("--%s must be RFC3339 (2006-01-02T15:04:05Z) or YYYY-MM-DD, got %q", flagName, val)
+					}
+					// Expand YYYY-MM-DD to start of day.
+					if flagName == "since" {
+						since = val + "T00:00:00Z"
+					} else {
+						until = val + "T23:59:59Z"
+					}
+				}
+			}
+
+			if all {
+				limit = 0 // 0 = no cap (store uses 0 to mean "no override")
+			}
+
+			f := store.MessagesFilter{
+				Stream: stream,
+				Topic:  topic,
+				Sender: sender,
+				Since:  since,
+				Until:  until,
+				Days:   days,
+				Hours:  hours,
+				Last:   last,
+				Limit:  limit,
+			}
+			if all {
+				f.Limit = -1 // signal to store: no cap
+			}
+
+			msgs, err := st.QueryMessages(cmd.Context(), f)
+			if err != nil {
+				return err
+			}
+			if len(msgs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No messages found.")
+				return nil
+			}
+			for _, m := range msgs {
+				timeText := m.Timestamp
+				if t, err2 := time.Parse(time.RFC3339, m.Timestamp); err2 == nil {
+					timeText = t.Format("2006-01-02 15:04:05")
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "[%s] #%s > %s | %s\n  %s\n\n",
+					timeText, m.StreamName, m.TopicName, m.SenderName, m.Content)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "(%d messages)\n", len(msgs))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&stream, "stream", "", "filter by stream name")
+	cmd.Flags().StringVar(&topic, "topic", "", "filter by topic name (exact match)")
+	cmd.Flags().StringVar(&sender, "sender", "", "filter by sender full name (substring match)")
+	cmd.Flags().StringVar(&since, "since", "", "only messages at or after this time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&until, "until", "", "only messages at or before this time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().IntVar(&days, "days", 0, "only messages from the last N days")
+	cmd.Flags().IntVar(&hours, "hours", 0, "only messages from the last N hours")
+	cmd.Flags().IntVar(&last, "last", 0, "return the N most recent messages (oldest-first output)")
+	cmd.Flags().IntVar(&limit, "limit", 200, "maximum messages to return (default 200)")
+	cmd.Flags().BoolVar(&all, "all", false, "remove safety limit and return all matching messages")
+	return cmd
 }
 
 func applyOpenClawConfig(path string, cfg *config.Config) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -529,6 +529,138 @@ func (s *Store) ReindexFTS(ctx context.Context) error {
 	return tx.Commit()
 }
 
+// MessageRow is a single message returned by QueryMessages.
+type MessageRow struct {
+	ID         int64
+	StreamName string
+	TopicName  string
+	SenderName string
+	Timestamp  string
+	Content    string
+}
+
+// MessagesFilter specifies which messages to return. At least one narrowing
+// criterion must be set by the caller; the store itself does not enforce the
+// requirement — that is done in the CLI layer.
+type MessagesFilter struct {
+	Stream string // stream name (exact match)
+	Topic  string // topic name  (exact match)
+	Sender string // sender full_name LIKE search
+
+	// Time window — RFC3339 timestamps, both optional.
+	Since string
+	Until string
+
+	// Convenience windows — applied as "now - duration".
+	// Days and Hours are cumulative (whichever is non-zero is added).
+	Days  int
+	Hours int
+
+	// Last N (sorted DESC inside, reversed before return).
+	Last int
+
+	// Hard cap; 0 means use default.
+	Limit int
+}
+
+// QueryMessages returns messages matching f, always ordered oldest-first.
+func (s *Store) QueryMessages(ctx context.Context, f MessagesFilter) ([]MessageRow, error) {
+	// Determine the effective limit.
+	// -1 means "no cap" (--all flag), 0 means "use default 200", >0 is explicit.
+	noLimit := f.Limit == -1
+	limit := f.Limit
+	if limit <= 0 && !noLimit {
+		limit = 200
+	}
+
+	q := `
+SELECT m.id, st.name, t.name, COALESCE(u.full_name,''), m.timestamp, m.content_text
+FROM messages m
+JOIN streams st ON st.id = m.stream_id
+JOIN topics t ON t.id = m.topic_id
+JOIN users u ON u.id = m.sender_id
+WHERE 1=1`
+	var args []any
+
+	if f.Stream != "" {
+		q += " AND st.name = ?"
+		args = append(args, f.Stream)
+	}
+	if f.Topic != "" {
+		q += " AND t.name = ?"
+		args = append(args, f.Topic)
+	}
+	if f.Sender != "" {
+		q += " AND u.full_name LIKE ?"
+		args = append(args, "%"+f.Sender+"%")
+	}
+	if f.Since != "" {
+		q += " AND m.timestamp >= ?"
+		args = append(args, f.Since)
+	}
+	if f.Until != "" {
+		q += " AND m.timestamp <= ?"
+		args = append(args, f.Until)
+	}
+	if f.Days > 0 || f.Hours > 0 {
+		window := time.Now().UTC().
+			Add(-time.Duration(f.Days)*24*time.Hour).
+			Add(-time.Duration(f.Hours)*time.Hour).
+			Format(time.RFC3339)
+		q += " AND m.timestamp >= ?"
+		args = append(args, window)
+	}
+
+	if f.Last > 0 {
+		// Pull the newest N then reverse them to oldest-first.
+		q += " ORDER BY m.timestamp DESC LIMIT ?"
+		args = append(args, f.Last)
+		rows, err := s.db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		var out []MessageRow
+		for rows.Next() {
+			var r MessageRow
+			if err := rows.Scan(&r.ID, &r.StreamName, &r.TopicName, &r.SenderName, &r.Timestamp, &r.Content); err != nil {
+				return nil, err
+			}
+			out = append(out, r)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		// Reverse to oldest-first.
+		for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+			out[i], out[j] = out[j], out[i]
+		}
+		return out, nil
+	}
+
+	if noLimit {
+		q += " ORDER BY m.timestamp ASC"
+	} else {
+		q += " ORDER BY m.timestamp ASC LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []MessageRow
+	for rows.Next() {
+		var r MessageRow
+		if err := rows.Scan(&r.ID, &r.StreamName, &r.TopicName, &r.SenderName, &r.Timestamp, &r.Content); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -563,6 +563,13 @@ type MessagesFilter struct {
 	Limit int
 }
 
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 // QueryMessages returns messages matching f, always ordered oldest-first.
 func (s *Store) QueryMessages(ctx context.Context, f MessagesFilter) ([]MessageRow, error) {
 	// Determine the effective limit.
@@ -591,8 +598,8 @@ WHERE 1=1`
 		args = append(args, f.Topic)
 	}
 	if f.Sender != "" {
-		q += " AND u.full_name LIKE ?"
-		args = append(args, "%"+f.Sender+"%")
+		q += ` AND u.full_name LIKE ? ESCAPE '\'`
+		args = append(args, "%"+escapeLike(f.Sender)+"%")
 	}
 	if f.Since != "" {
 		q += " AND m.timestamp >= ?"
@@ -604,8 +611,8 @@ WHERE 1=1`
 	}
 	if f.Days > 0 || f.Hours > 0 {
 		window := time.Now().UTC().
-			Add(-time.Duration(f.Days)*24*time.Hour).
-			Add(-time.Duration(f.Hours)*time.Hour).
+			Add(-time.Duration(f.Days) * 24 * time.Hour).
+			Add(-time.Duration(f.Hours) * time.Hour).
 			Format(time.RFC3339)
 		q += " AND m.timestamp >= ?"
 		args = append(args, window)

--- a/internal/store/store_messages_test.go
+++ b/internal/store/store_messages_test.go
@@ -1,0 +1,325 @@
+package store_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+// openTestStore opens a fresh in-memory-style SQLite DB in a temp dir.
+func openTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return st
+}
+
+// seedDB inserts the minimum org/stream/user/topic/message fixtures needed
+// by the query-messages tests. Returns stream IDs keyed by name.
+func seedDB(t *testing.T, st *store.Store) map[string]int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := st.UpsertOrganization(ctx, 1, "https://z.example.com", "TestOrg"); err != nil {
+		t.Fatal(err)
+	}
+
+	streams := map[string]int64{"general": 1, "dev": 2}
+	for name, id := range streams {
+		if err := st.UpsertStream(ctx, store.Stream{ID: id, OrgID: 1, Name: name}); err != nil {
+			t.Fatalf("UpsertStream %s: %v", name, err)
+		}
+	}
+
+	users := []store.User{
+		{ID: 10, OrgID: 1, FullName: "Alice"},
+		{ID: 11, OrgID: 1, FullName: "Bob"},
+	}
+	for _, u := range users {
+		if err := st.UpsertUser(ctx, u); err != nil {
+			t.Fatalf("UpsertUser %s: %v", u.FullName, err)
+		}
+	}
+
+	// topic IDs are autoincrement; seed order matters.
+	topicFixtures := []struct {
+		streamID int64
+		name     string
+	}{
+		{1, "deploys"},
+		{1, "random"},
+		{2, "bugs"},
+	}
+	topicIDs := map[string]int64{}
+	for _, tf := range topicFixtures {
+		id, err := st.GetOrCreateTopic(ctx, 1, tf.streamID, tf.name)
+		if err != nil {
+			t.Fatalf("GetOrCreateTopic %s: %v", tf.name, err)
+		}
+		topicIDs[tf.name] = id
+	}
+
+	now := time.Now().UTC()
+	msgs := []struct {
+		id        int64
+		streamID  int64
+		topicName string
+		senderID  int64
+		ts        time.Time
+		content   string
+	}{
+		// general/deploys – 3 messages
+		{1001, 1, "deploys", 10, now.Add(-8 * 24 * time.Hour), "deployed v1"},
+		{1002, 1, "deploys", 11, now.Add(-5 * 24 * time.Hour), "deployed v2"},
+		{1003, 1, "deploys", 10, now.Add(-1 * time.Hour), "deployed v3"},
+		// general/random – 2 messages
+		{2001, 1, "random", 11, now.Add(-2 * 24 * time.Hour), "hello world"},
+		{2002, 1, "random", 10, now.Add(-30 * time.Minute), "bye world"},
+		// dev/bugs – 1 message
+		{3001, 2, "bugs", 11, now.Add(-3 * 24 * time.Hour), "nil pointer"},
+	}
+	for _, m := range msgs {
+		if err := st.UpsertMessage(ctx, store.Message{
+			ID:          m.id,
+			OrgID:       1,
+			StreamID:    m.streamID,
+			TopicID:     topicIDs[m.topicName],
+			SenderID:    m.senderID,
+			Content:     m.content,
+			ContentText: m.content,
+			Timestamp:   m.ts.Format(time.RFC3339),
+		}); err != nil {
+			t.Fatalf("UpsertMessage %d: %v", m.id, err)
+		}
+	}
+	return streams
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+func TestQueryMessages_ByStream(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Stream: "general",
+		Limit:  200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 messages in 'general', got %d", len(rows))
+	}
+	// Verify oldest-first order.
+	for i := 1; i < len(rows); i++ {
+		if rows[i].Timestamp < rows[i-1].Timestamp {
+			t.Errorf("messages not in ascending order at index %d", i)
+		}
+	}
+}
+
+func TestQueryMessages_ByStreamAndTopic(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Stream: "general",
+		Topic:  "deploys",
+		Limit:  200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 messages in deploys, got %d", len(rows))
+	}
+}
+
+func TestQueryMessages_BySender(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Sender: "Alice",
+		Limit:  200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Alice sent: 1001, 1003, 2002 = 3
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 messages from Alice, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.SenderName != "Alice" {
+			t.Errorf("expected sender Alice, got %s", r.SenderName)
+		}
+	}
+}
+
+func TestQueryMessages_ByDays(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	// Only messages from last 3 days: 1003 (1h ago), 2001 (2d ago), 2002 (30m ago), 3001 (3d ago)
+	// Boundary is fuzzy; use 4 days to be safe about rounding.
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Days:  4,
+		Limit: 200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected some messages from last 4 days")
+	}
+	// None should be older than 4 days.
+	cutoff := time.Now().UTC().Add(-4 * 24 * time.Hour)
+	for _, r := range rows {
+		ts, err := time.Parse(time.RFC3339, r.Timestamp)
+		if err != nil {
+			t.Errorf("bad timestamp %q: %v", r.Timestamp, err)
+			continue
+		}
+		if ts.Before(cutoff) {
+			t.Errorf("message %d is older than 4 days: %s", r.ID, r.Timestamp)
+		}
+	}
+}
+
+func TestQueryMessages_ByHours(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Hours: 2,
+		Limit: 200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expect: 1003 (1h ago), 2002 (30m ago) = 2
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 messages in last 2 hours, got %d", len(rows))
+	}
+}
+
+func TestQueryMessages_BySince(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	since := time.Now().UTC().Add(-6 * 24 * time.Hour).Format(time.RFC3339)
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Since: since,
+		Limit: 200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1002 (5d), 1003 (1h), 2001 (2d), 2002 (30m), 3001 (3d) = 5
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 messages since 6 days ago, got %d", len(rows))
+	}
+}
+
+func TestQueryMessages_LastN(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Sender: "Bob", // Bob: 1002, 2001, 3001
+		Last:   2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 messages (last 2 from Bob), got %d", len(rows))
+	}
+	// Must be oldest-first (ascending).
+	if rows[0].Timestamp > rows[1].Timestamp {
+		t.Errorf("last N result is not oldest-first: %s > %s", rows[0].Timestamp, rows[1].Timestamp)
+	}
+	// The 2 newest from Bob should be 2001 and 3001 (relative to the 3 Bob msgs).
+	// Order: 2001 then 3001 (ascending).
+}
+
+func TestQueryMessages_DefaultLimit(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	// No explicit limit (0 = default 200).
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Stream: "general",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should get all 5 general messages (well under default 200).
+	if len(rows) != 5 {
+		t.Fatalf("expected 5, got %d", len(rows))
+	}
+}
+
+func TestQueryMessages_AllFlag(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	// -1 = no cap
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Stream: "general",
+		Limit:  -1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 with --all, got %d", len(rows))
+	}
+}
+
+func TestQueryMessages_DevStream(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.QueryMessages(context.Background(), store.MessagesFilter{
+		Stream: "dev",
+		Limit:  200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 message in dev, got %d", len(rows))
+	}
+	if rows[0].StreamName != "dev" {
+		t.Errorf("expected stream dev, got %s", rows[0].StreamName)
+	}
+}
+
+// Verify that the os package import is not needed beyond tempdir.
+var _ = os.DevNull

--- a/internal/store/store_messages_test.go
+++ b/internal/store/store_messages_test.go
@@ -323,3 +323,38 @@ func TestQueryMessages_DevStream(t *testing.T) {
 
 // Verify that the os package import is not needed beyond tempdir.
 var _ = os.DevNull
+
+func TestQueryMessages_SenderEscapesLikeWildcards(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	ctx := context.Background()
+	if err := st.UpsertUser(ctx, store.User{ID: 12, OrgID: 1, FullName: "A_lice"}); err != nil {
+		t.Fatal(err)
+	}
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 1, "deploys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertMessage(ctx, store.Message{
+		ID:          4001,
+		OrgID:       1,
+		StreamID:    1,
+		TopicID:     topicID,
+		SenderID:    12,
+		Content:     "literal underscore sender",
+		ContentText: "literal underscore sender",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := st.QueryMessages(ctx, store.MessagesFilter{Sender: "A_", Limit: 200})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].SenderName != "A_lice" {
+		t.Fatalf("expected only literal underscore sender, got %#v", rows)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `zulcrawl messages` for exact archive slices from the local SQLite DB.

Closes #5

## Usage

```
# By stream + topic + time window
zulcrawl messages --stream general --topic "deploys" --days 7

# Recent window only
zulcrawl messages --stream general --hours 6

# By sender, newest N (printed oldest-first)
zulcrawl messages --sender "Ian" --last 50

# Since a specific timestamp
zulcrawl messages --since 2026-04-01T00:00:00Z
zulcrawl messages --since 2026-04-01   # YYYY-MM-DD also accepted

# Safety: at least one filter required; default cap 200
zulcrawl messages --stream general --limit 50
zulcrawl messages --stream general --all   # remove cap
```

## Changes

- **`internal/store/store.go`** — `MessagesFilter` struct + `QueryMessages` method
  - Supports: stream, topic, sender (substring), since/until (RFC3339 or YYYY-MM-DD), days/hours window, last-N (newest-to-DB, reversed to oldest-first output), limit, and no-cap (-1) mode
- **`internal/cli/root.go`** — `messagesCmd` wired into root
  - Validates filters, requires at least one narrowing criterion
  - Writes output via `cmd.OutOrStdout()` (testable)
- **`internal/store/store_messages_test.go`** — 10 store-layer tests
- **`internal/cli/messages_test.go`** — 11 CLI integration tests

## Out of scope (per issue)
- mentions indexing, attachment indexing, semantic search, MCP, Git snapshots, event tailing

## Verification

```
go test ./...          # all pass
govulncheck ./...      # no vulnerabilities found
```

## Workspace
- Path: `/Volumes/WorkingSpace/openclaw/workspaces/rex/zulcrawl`
- Writable: ✅
- Go version: go1.26.1 darwin/arm64