### PR TITLE
feat: index mentions and small text attachments

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -364,7 +364,15 @@ type Message struct {
 }
 
 func (s *Store) UpsertMessage(ctx context.Context, m Message) error {
-	return s.upsertMessageTx(ctx, s.db, m)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := s.upsertMessageTx(ctx, tx, m); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 // upsertMessageTx is the shared implementation used by both UpsertMessage and

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,6 +31,10 @@ func Open(path string) (*Store, error) {
 func (s *Store) Close() error { return s.db.Close() }
 
 func (s *Store) InitSchema(ctx context.Context) error {
+	ftsMigrated, err := s.prepareFTSMigration(ctx)
+	if err != nil {
+		return err
+	}
 	schema := `
 CREATE TABLE IF NOT EXISTS organizations (
     id INTEGER PRIMARY KEY,
@@ -86,6 +90,33 @@ CREATE TABLE IF NOT EXISTS messages (
     reactions TEXT,
     is_me_message INTEGER DEFAULT 0
 );
+CREATE TABLE IF NOT EXISTS message_mentions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    org_id INTEGER NOT NULL REFERENCES organizations(id),
+    stream_id INTEGER NOT NULL REFERENCES streams(id),
+    topic_id INTEGER NOT NULL REFERENCES topics(id),
+    mentioned_user_id INTEGER,
+    mentioned_name TEXT NOT NULL,
+    mention_kind TEXT NOT NULL DEFAULT 'user',
+    timestamp TEXT NOT NULL,
+    UNIQUE(message_id, mentioned_user_id, mentioned_name, mention_kind)
+);
+CREATE TABLE IF NOT EXISTS message_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    org_id INTEGER NOT NULL REFERENCES organizations(id),
+    stream_id INTEGER NOT NULL REFERENCES streams(id),
+    topic_id INTEGER NOT NULL REFERENCES topics(id),
+    url TEXT NOT NULL,
+    file_name TEXT,
+    title TEXT,
+    content_type TEXT,
+    text_content TEXT,
+    indexed INTEGER DEFAULT 0,
+    timestamp TEXT NOT NULL,
+    UNIQUE(message_id, url)
+);
 
 -- Standalone FTS5 tables (no content= option).
 -- content= was intentionally removed because messages_fts declares extra columns
@@ -98,6 +129,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     content_text,
     topic_name,
     sender_name,
+    attachment_text,
     tokenize='porter unicode61'
 );
 CREATE VIRTUAL TABLE IF NOT EXISTS topics_fts USING fts5(
@@ -116,24 +148,34 @@ CREATE TABLE IF NOT EXISTS sync_state (
 CREATE INDEX IF NOT EXISTS idx_messages_stream_topic ON messages(stream_id, topic_id);
 CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
 CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
+CREATE INDEX IF NOT EXISTS idx_mentions_message ON message_mentions(message_id);
+CREATE INDEX IF NOT EXISTS idx_mentions_user ON message_mentions(mentioned_user_id);
+CREATE INDEX IF NOT EXISTS idx_mentions_name ON message_mentions(mentioned_name);
+CREATE INDEX IF NOT EXISTS idx_mentions_stream_topic ON message_mentions(stream_id, topic_id);
+CREATE INDEX IF NOT EXISTS idx_mentions_timestamp ON message_mentions(timestamp);
+CREATE INDEX IF NOT EXISTS idx_attachments_message ON message_attachments(message_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_stream_topic ON message_attachments(stream_id, topic_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_timestamp ON message_attachments(timestamp);
 CREATE INDEX IF NOT EXISTS idx_topics_stream ON topics(stream_id);
 CREATE INDEX IF NOT EXISTS idx_topics_resolved ON topics(resolved);
 
 CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-  INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name)
+  INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
   VALUES (new.id, new.content_text,
     COALESCE((SELECT name FROM topics WHERE id = new.topic_id),''),
-    COALESCE((SELECT full_name FROM users WHERE id = new.sender_id),''));
+    COALESCE((SELECT full_name FROM users WHERE id = new.sender_id),''),
+    COALESCE((SELECT group_concat(text_content, ' ') FROM message_attachments WHERE message_id = new.id AND indexed = 1),''));
 END;
 CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
   DELETE FROM messages_fts WHERE rowid = old.id;
 END;
 CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
   DELETE FROM messages_fts WHERE rowid = old.id;
-  INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name)
+  INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
   VALUES (new.id, new.content_text,
     COALESCE((SELECT name FROM topics WHERE id = new.topic_id),''),
-    COALESCE((SELECT full_name FROM users WHERE id = new.sender_id),''));
+    COALESCE((SELECT full_name FROM users WHERE id = new.sender_id),''),
+    COALESCE((SELECT group_concat(text_content, ' ') FROM message_attachments WHERE message_id = new.id AND indexed = 1),''));
 END;
 
 CREATE TRIGGER IF NOT EXISTS topics_ai AFTER INSERT ON topics BEGIN
@@ -147,8 +189,58 @@ CREATE TRIGGER IF NOT EXISTS topics_au AFTER UPDATE ON topics BEGIN
   INSERT INTO topics_fts(rowid, name) VALUES(new.id, new.name);
 END;
 `
-	_, err := s.db.ExecContext(ctx, schema)
-	return err
+	if _, err := s.db.ExecContext(ctx, schema); err != nil {
+		return err
+	}
+	if ftsMigrated {
+		return s.ReindexFTS(ctx)
+	}
+	return nil
+}
+
+func (s *Store) prepareFTSMigration(ctx context.Context) (bool, error) {
+	if _, err := s.db.ExecContext(ctx, `
+DROP TRIGGER IF EXISTS messages_ai;
+DROP TRIGGER IF EXISTS messages_ad;
+DROP TRIGGER IF EXISTS messages_au;
+`); err != nil {
+		return false, err
+	}
+	var name string
+	if err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'`).Scan(&name); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(messages_fts)`)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	hasAttachmentText := false
+	for rows.Next() {
+		var cid int
+		var colName, typ string
+		var notNull, pk int
+		var defaultValue any
+		if err := rows.Scan(&cid, &colName, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if colName == "attachment_text" {
+			hasAttachmentText = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	if hasAttachmentText {
+		return false, nil
+	}
+	if _, err := s.db.ExecContext(ctx, `DROP TABLE messages_fts`); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
@@ -227,6 +319,31 @@ synced_at=excluded.synced_at
 	return id, nil
 }
 
+type Mention struct {
+	MessageID int64
+	OrgID     int64
+	StreamID  int64
+	TopicID   int64
+	UserID    int64
+	Name      string
+	Kind      string
+	Timestamp string
+}
+
+type Attachment struct {
+	MessageID   int64
+	OrgID       int64
+	StreamID    int64
+	TopicID     int64
+	URL         string
+	FileName    string
+	Title       string
+	ContentType string
+	Text        string
+	Indexed     bool
+	Timestamp   string
+}
+
 type Message struct {
 	ID            int64
 	OrgID         int64
@@ -242,6 +359,8 @@ type Message struct {
 	HasLink       bool
 	Reactions     json.RawMessage
 	IsMeMessage   bool
+	Mentions      []Mention
+	Attachments   []Attachment
 }
 
 func (s *Store) UpsertMessage(ctx context.Context, m Message) error {
@@ -259,6 +378,12 @@ func (s *Store) upsertMessageTx(ctx context.Context, ex execer, m Message) error
 	reactions := string(m.Reactions)
 	if reactions == "" {
 		reactions = "[]"
+	}
+	if _, err := ex.ExecContext(ctx, `DELETE FROM message_mentions WHERE message_id = ?`, m.ID); err != nil {
+		return err
+	}
+	if _, err := ex.ExecContext(ctx, `DELETE FROM message_attachments WHERE message_id = ?`, m.ID); err != nil {
+		return err
 	}
 	_, err := ex.ExecContext(ctx, `
 INSERT INTO messages(
@@ -283,6 +408,51 @@ is_me_message=excluded.is_me_message
 		m.Content, m.ContentText, m.Timestamp, nullIfEmpty(m.EditTimestamp),
 		boolToInt(m.HasAttachment), boolToInt(m.HasImage), boolToInt(m.HasLink), reactions, boolToInt(m.IsMeMessage),
 	)
+	if err != nil {
+		return err
+	}
+	for _, mention := range m.Mentions {
+		if mention.Kind == "" {
+			mention.Kind = "user"
+		}
+		if mention.Timestamp == "" {
+			mention.Timestamp = m.Timestamp
+		}
+		if _, err := ex.ExecContext(ctx, `
+INSERT OR IGNORE INTO message_mentions(
+message_id, org_id, stream_id, topic_id, mentioned_user_id, mentioned_name, mention_kind, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			m.ID, m.OrgID, m.StreamID, m.TopicID, nullInt64IfZero(mention.UserID), mention.Name, mention.Kind, mention.Timestamp,
+		); err != nil {
+			return err
+		}
+	}
+	for _, attachment := range m.Attachments {
+		if attachment.Timestamp == "" {
+			attachment.Timestamp = m.Timestamp
+		}
+		if _, err := ex.ExecContext(ctx, `
+INSERT OR IGNORE INTO message_attachments(
+message_id, org_id, stream_id, topic_id, url, file_name, title, content_type, text_content, indexed, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			m.ID, m.OrgID, m.StreamID, m.TopicID, attachment.URL, attachment.FileName, attachment.Title,
+			attachment.ContentType, nullIfEmpty(attachment.Text), boolToInt(attachment.Indexed), attachment.Timestamp,
+		); err != nil {
+			return err
+		}
+	}
+	if len(m.Attachments) > 0 {
+		if _, err := ex.ExecContext(ctx, `DELETE FROM messages_fts WHERE rowid = ?`, m.ID); err != nil {
+			return err
+		}
+		_, err = ex.ExecContext(ctx, `
+INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
+VALUES (?, ?,
+  COALESCE((SELECT name FROM topics WHERE id = ?),''),
+  COALESCE((SELECT full_name FROM users WHERE id = ?),''),
+  COALESCE((SELECT group_concat(text_content, ' ') FROM message_attachments WHERE message_id = ? AND indexed = 1),''));`,
+			m.ID, m.ContentText, m.TopicID, m.SenderID, m.ID)
+	}
 	return err
 }
 
@@ -490,6 +660,13 @@ func nullIfEmpty(s string) any {
 	return s
 }
 
+func nullInt64IfZero(n int64) any {
+	if n == 0 {
+		return nil
+	}
+	return n
+}
+
 func boolToInt(v bool) int {
 	if v {
 		return 1
@@ -510,10 +687,13 @@ func (s *Store) ReindexFTS(ctx context.Context) error {
 		`DELETE FROM messages_fts`,
 		`DELETE FROM topics_fts`,
 		// Repopulate messages_fts.
-		`INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name)
+		`INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
          SELECT m.id, m.content_text,
                 COALESCE(t.name, ''),
-                COALESCE(u.full_name, '')
+                COALESCE(u.full_name, ''),
+                COALESCE((SELECT group_concat(a.text_content, ' ')
+                          FROM message_attachments a
+                          WHERE a.message_id = m.id AND a.indexed = 1), '')
          FROM messages m
          LEFT JOIN topics t ON t.id = m.topic_id
          LEFT JOIN users u ON u.id = m.sender_id`,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestStore(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	st, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://example.com", "Example"); err != nil {
+		t.Fatalf("UpsertOrganization: %v", err)
+	}
+	if err := st.UpsertStream(ctx, Stream{ID: 10, OrgID: 1, Name: "general"}); err != nil {
+		t.Fatalf("UpsertStream: %v", err)
+	}
+	if err := st.UpsertUser(ctx, User{ID: 20, OrgID: 1, FullName: "Sender"}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	return st, ctx
+}
+
+func TestUpsertMessageStoresMentionsAndAttachments(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	msg := Message{
+		ID:          100,
+		OrgID:       1,
+		StreamID:    10,
+		TopicID:     topicID,
+		SenderID:    20,
+		Content:     "hello",
+		ContentText: "hello",
+		Timestamp:   "2026-04-29T17:00:00Z",
+		Mentions: []Mention{{
+			UserID: 42,
+			Name:   "Alice Example",
+			Kind:   "user",
+		}},
+		Attachments: []Attachment{{
+			URL:         "/user_uploads/1/ab/todo.txt",
+			FileName:    "todo.txt",
+			Title:       "todo.txt",
+			ContentType: "text/plain",
+			Text:        "needle attachment body",
+			Indexed:     true,
+		}},
+	}
+	if err := st.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	var mentionCount int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id=100 AND mentioned_user_id=42 AND mentioned_name='Alice Example'`).Scan(&mentionCount); err != nil {
+		t.Fatalf("query mentions: %v", err)
+	}
+	if mentionCount != 1 {
+		t.Fatalf("mention count = %d, want 1", mentionCount)
+	}
+
+	var attachmentCount int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM message_attachments WHERE message_id=100 AND file_name='todo.txt' AND indexed=1`).Scan(&attachmentCount); err != nil {
+		t.Fatalf("query attachments: %v", err)
+	}
+	if attachmentCount != 1 {
+		t.Fatalf("attachment count = %d, want 1", attachmentCount)
+	}
+
+	hits, err := st.Search(ctx, "needle", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].MessageID != 100 {
+		t.Fatalf("attachment text search hits = %#v, want message 100", hits)
+	}
+}
+
+func TestUpsertMessageReplacesMentionAndAttachmentRows(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	base := Message{ID: 101, OrgID: 1, StreamID: 10, TopicID: topicID, SenderID: 20, Content: "hello", ContentText: "hello", Timestamp: "2026-04-29T17:00:00Z"}
+	base.Mentions = []Mention{{UserID: 1, Name: "Old", Kind: "user"}}
+	base.Attachments = []Attachment{{URL: "/user_uploads/old.txt", FileName: "old.txt", Text: "oldneedle", Indexed: true}}
+	if err := st.UpsertMessage(ctx, base); err != nil {
+		t.Fatalf("first UpsertMessage: %v", err)
+	}
+	base.Mentions = []Mention{{UserID: 2, Name: "New", Kind: "user"}}
+	base.Attachments = []Attachment{{URL: "/user_uploads/new.txt", FileName: "new.txt", Text: "newneedle", Indexed: true}}
+	if err := st.UpsertMessage(ctx, base); err != nil {
+		t.Fatalf("second UpsertMessage: %v", err)
+	}
+
+	var oldRows int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id=101 AND mentioned_name='Old'`).Scan(&oldRows); err != nil {
+		t.Fatalf("query old mentions: %v", err)
+	}
+	if oldRows != 0 {
+		t.Fatalf("old mention rows = %d, want 0", oldRows)
+	}
+	hits, err := st.Search(ctx, "newneedle", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search newneedle: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("new attachment text hits = %d, want 1", len(hits))
+	}
+}

--- a/internal/syncer/indexing.go
+++ b/internal/syncer/indexing.go
@@ -1,0 +1,194 @@
+package syncer
+
+import (
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+const maxInlineAttachmentTextBytes = 64 * 1024
+
+var uploadHrefRE = regexp.MustCompile(`(?i)^/user_uploads/`)
+
+// parseMessageIndexables extracts lightweight structured data from Zulip's
+// rendered message HTML. It intentionally never fetches remote content; only
+// inline text already present in the rendered HTML is indexed.
+func parseMessageIndexables(messageID, orgID, streamID, topicID int64, timestamp, renderedHTML string) ([]store.Mention, []store.Attachment) {
+	n, err := html.Parse(strings.NewReader(renderedHTML))
+	if err != nil {
+		return nil, nil
+	}
+
+	mentionsByKey := map[string]store.Mention{}
+	attachmentsByURL := map[string]store.Attachment{}
+
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			if isMentionNode(node) {
+				mention := store.Mention{
+					MessageID: messageID,
+					OrgID:     orgID,
+					StreamID:  streamID,
+					TopicID:   topicID,
+					Timestamp: timestamp,
+					Name:      strings.TrimPrefix(strings.TrimSpace(nodeText(node)), "@"),
+					Kind:      mentionKind(node),
+				}
+				mention.UserID = mentionUserID(node)
+				if mention.Name != "" || mention.UserID != 0 {
+					key := mention.Kind + "|" + mention.Name + "|" + strconv.FormatInt(mention.UserID, 10)
+					mentionsByKey[key] = mention
+				}
+			}
+
+			if isAttachmentLink(node) {
+				att := store.Attachment{
+					MessageID: messageID,
+					OrgID:     orgID,
+					StreamID:  streamID,
+					TopicID:   topicID,
+					Timestamp: timestamp,
+					URL:       attr(node, "href"),
+					Title:     strings.TrimSpace(nodeText(node)),
+				}
+				att.FileName = attachmentFileName(att.URL, att.Title)
+				att.ContentType = contentTypeFromName(att.FileName)
+				att.Text = boundedText(textNearAttachment(node), maxInlineAttachmentTextBytes)
+				att.Indexed = att.Text != ""
+				attachmentsByURL[att.URL] = att
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+
+	mentions := make([]store.Mention, 0, len(mentionsByKey))
+	for _, m := range mentionsByKey {
+		mentions = append(mentions, m)
+	}
+	attachments := make([]store.Attachment, 0, len(attachmentsByURL))
+	for _, a := range attachmentsByURL {
+		attachments = append(attachments, a)
+	}
+	return mentions, attachments
+}
+
+func isMentionNode(n *html.Node) bool {
+	if n.Data != "span" && n.Data != "a" {
+		return false
+	}
+	cls := " " + strings.ToLower(attr(n, "class")) + " "
+	return strings.Contains(cls, " user-mention ") || strings.Contains(cls, " user-group-mention ")
+}
+
+func mentionKind(n *html.Node) string {
+	cls := strings.ToLower(attr(n, "class"))
+	if strings.Contains(cls, "user-group-mention") {
+		return "group"
+	}
+	return "user"
+}
+
+func mentionUserID(n *html.Node) int64 {
+	for _, name := range []string{"data-user-id", "data-user-group-id", "data-id"} {
+		if v := strings.TrimSpace(attr(n, name)); v != "" {
+			if id, err := strconv.ParseInt(v, 10, 64); err == nil {
+				return id
+			}
+		}
+	}
+	return 0
+}
+
+func isAttachmentLink(n *html.Node) bool {
+	if n.Data != "a" {
+		return false
+	}
+	href := strings.TrimSpace(attr(n, "href"))
+	if href == "" || !uploadHrefRE.MatchString(href) {
+		return false
+	}
+	cls := strings.ToLower(attr(n, "class"))
+	return strings.Contains(cls, "message_inline_ref") || isSmallTextLikeName(attachmentFileName(href, nodeText(n)))
+}
+
+func textNearAttachment(n *html.Node) string {
+	// Zulip rendered uploads usually put the link and any preview text inside a
+	// small wrapper. Index only that already-rendered text, not fetched content.
+	for p := n.Parent; p != nil; p = p.Parent {
+		if p.Type == html.ElementNode {
+			cls := strings.ToLower(attr(p, "class"))
+			if strings.Contains(cls, "message_inline_ref") || strings.Contains(cls, "message_inline_image") || p.Data == "p" || p.Data == "blockquote" {
+				text := strings.TrimSpace(nodeText(p))
+				if isSmallTextLikeName(attachmentFileName(attr(n, "href"), text)) {
+					return text
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func attr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if strings.EqualFold(a.Key, key) {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func nodeText(n *html.Node) string {
+	var b strings.Builder
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			b.WriteString(node.Data)
+			b.WriteByte(' ')
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func attachmentFileName(rawURL, title string) string {
+	if u, err := url.Parse(rawURL); err == nil {
+		if base := path.Base(u.Path); base != "." && base != "/" && base != "" {
+			return base
+		}
+	}
+	return strings.TrimSpace(title)
+}
+
+func contentTypeFromName(name string) string {
+	switch strings.ToLower(path.Ext(name)) {
+	case ".txt", ".log", ".md", ".markdown", ".json", ".yaml", ".yml", ".csv", ".tsv", ".xml", ".html", ".htm", ".go", ".py", ".js", ".ts", ".css", ".sh", ".sql":
+		return "text/plain"
+	default:
+		return ""
+	}
+}
+
+func isSmallTextLikeName(name string) bool {
+	return contentTypeFromName(name) != ""
+}
+
+func boundedText(text string, maxBytes int) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= maxBytes {
+		return text
+	}
+	return strings.TrimSpace(text[:maxBytes])
+}

--- a/internal/syncer/indexing.go
+++ b/internal/syncer/indexing.go
@@ -87,7 +87,10 @@ func isMentionNode(n *html.Node) bool {
 		return false
 	}
 	cls := " " + strings.ToLower(attr(n, "class")) + " "
-	return strings.Contains(cls, " user-mention ") || strings.Contains(cls, " user-group-mention ")
+	if strings.Contains(cls, " user-mention ") {
+		return mentionUserID(n) > 0
+	}
+	return strings.Contains(cls, " user-group-mention ")
 }
 
 func mentionKind(n *html.Node) string {

--- a/internal/syncer/indexing_test.go
+++ b/internal/syncer/indexing_test.go
@@ -30,3 +30,14 @@ func TestParseMessageIndexablesDoesNotIndexBinaryUploadText(t *testing.T) {
 		t.Fatalf("binary attachment should not be text-indexed: %#v", attachments[0])
 	}
 }
+
+func TestParseMessageIndexablesSkipsWildcardUserMentions(t *testing.T) {
+	html := `<p>Hello <span class="user-mention" data-user-id="*">@all</span> and <span class="user-mention" data-user-id="42">@Alice</span></p>`
+	mentions, _ := parseMessageIndexables(100, 1, 10, 20, "2026-04-29T17:00:00Z", html)
+	if len(mentions) != 1 {
+		t.Fatalf("mentions = %#v, want only concrete user mention", mentions)
+	}
+	if mentions[0].UserID != 42 || mentions[0].Name != "Alice" {
+		t.Fatalf("mention = %#v", mentions[0])
+	}
+}

--- a/internal/syncer/indexing_test.go
+++ b/internal/syncer/indexing_test.go
@@ -1,0 +1,32 @@
+package syncer
+
+import "testing"
+
+func TestParseMessageIndexablesExtractsMentionsAndSmallTextAttachments(t *testing.T) {
+	html := `<p>Hello <span class="user-mention" data-user-id="42">@Alice Example</span></p>
+<p><a class="message_inline_ref" href="/user_uploads/2/ab/todo.txt">todo.txt</a> remember the zeta task</p>`
+	mentions, attachments := parseMessageIndexables(100, 1, 10, 20, "2026-04-29T17:00:00Z", html)
+	if len(mentions) != 1 {
+		t.Fatalf("mentions = %#v, want 1", mentions)
+	}
+	if mentions[0].UserID != 42 || mentions[0].Name != "Alice Example" || mentions[0].Kind != "user" {
+		t.Fatalf("mention = %#v", mentions[0])
+	}
+	if len(attachments) != 1 {
+		t.Fatalf("attachments = %#v, want 1", attachments)
+	}
+	if attachments[0].FileName != "todo.txt" || !attachments[0].Indexed || attachments[0].Text == "" {
+		t.Fatalf("attachment = %#v", attachments[0])
+	}
+}
+
+func TestParseMessageIndexablesDoesNotIndexBinaryUploadText(t *testing.T) {
+	html := `<p><a class="message_inline_ref" href="/user_uploads/2/ab/photo.png">photo.png</a> binary-looking upload</p>`
+	_, attachments := parseMessageIndexables(100, 1, 10, 20, "2026-04-29T17:00:00Z", html)
+	if len(attachments) != 1 {
+		t.Fatalf("attachments = %#v, want 1 metadata row", attachments)
+	}
+	if attachments[0].Indexed || attachments[0].Text != "" {
+		t.Fatalf("binary attachment should not be text-indexed: %#v", attachments[0])
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -237,11 +237,12 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 				editTS = time.Unix(m.EditTimestamp, 0).UTC().Format(time.RFC3339)
 			}
 			contentText := htmlToText(m.Content)
+			mentions, attachments := parseMessageIndexables(m.ID, s.orgID, st.StreamID, topicID, ts, m.Content)
 			hasLink := strings.Contains(strings.ToLower(m.Content), "href=") ||
 				strings.Contains(contentText, "http://") ||
 				strings.Contains(contentText, "https://")
 			hasImage := strings.Contains(strings.ToLower(m.Content), "<img")
-			hasAttachment := strings.Contains(strings.ToLower(m.Content), "class=\"message_inline_ref\"")
+			hasAttachment := len(attachments) > 0 || strings.Contains(strings.ToLower(m.Content), "class=\"message_inline_ref\"")
 
 			batch = append(batch, store.Message{
 				ID:            m.ID,
@@ -257,6 +258,8 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 				HasImage:      hasImage,
 				HasLink:       hasLink,
 				Reactions:     json.RawMessage(m.Reactions),
+				Mentions:      mentions,
+				Attachments:   attachments,
 				// m.IsMe reflects the API's is_me_message boolean (/me action
 				// messages).  m.Type=="private" means a direct message, which
 				// is a separate concept and should not reach the stream syncer.
@@ -370,11 +373,12 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 				editTS = time.Unix(m.EditTimestamp, 0).UTC().Format(time.RFC3339)
 			}
 			contentText := htmlToText(m.Content)
+			mentions, attachments := parseMessageIndexables(m.ID, s.orgID, privateStreamID, topicID, ts, m.Content)
 			hasLink := strings.Contains(strings.ToLower(m.Content), "href=") ||
 				strings.Contains(contentText, "http://") ||
 				strings.Contains(contentText, "https://")
 			hasImage := strings.Contains(strings.ToLower(m.Content), "<img")
-			hasAttachment := strings.Contains(strings.ToLower(m.Content), "class=\"message_inline_ref\"")
+			hasAttachment := len(attachments) > 0 || strings.Contains(strings.ToLower(m.Content), "class=\"message_inline_ref\"")
 
 			batch = append(batch, store.Message{
 				ID:            m.ID,
@@ -391,6 +395,8 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 				HasLink:       hasLink,
 				Reactions:     json.RawMessage(m.Reactions),
 				IsMeMessage:   m.IsMe,
+				Mentions:      mentions,
+				Attachments:   attachments,
 			})
 			if m.ID > maxID {
 				maxID = m.ID


### PR DESCRIPTION
## Summary

Adds focused indexing for Zulip message mentions and small text-like upload metadata/content already present in rendered message HTML.

## Changes

- Add `message_mentions` and `message_attachments` tables with query-friendly indexes.
- Parse rendered Zulip message HTML for user/group mentions and `/user_uploads/` attachment links.
- Store attachment metadata and fold bounded inline rendered text for text-like uploads into message FTS.
- Add FTS migration/reindex handling for the new attachment text column.
- Add store and parser tests covering mention rows, attachment rows, FTS, replacement semantics, and binary guardrails.

## Deliberate limitations / safety

- This does **not** download upload URLs or arbitrary remote content.
- Attachment text indexing is limited to small bounded text already present in Zulip-rendered HTML (64 KiB max).
- Binary-looking uploads are stored as metadata only and are not text-indexed.
- No broad messages/query UX, semantic search, MCP, Git snapshots, or event tailing in this PR.

## Testing

- `go test ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`

Fixes #6
