### PR TITLE
feat: add backfill-indexes command for mention and attachment indexes

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(statsCmd(loadCfg))
 	root.AddCommand(sqlCmd(loadCfg))
 	root.AddCommand(messagesCmd(loadCfg))
+	root.AddCommand(backfillIndexesCmd(loadCfg))
 	return root
 }
 
@@ -466,6 +467,43 @@ The default safety limit is 200 messages; use --limit or --all to override.`,
 	cmd.Flags().IntVar(&last, "last", 0, "return the N most recent messages (oldest-first output)")
 	cmd.Flags().IntVar(&limit, "limit", 200, "maximum messages to return (default 200)")
 	cmd.Flags().BoolVar(&all, "all", false, "remove safety limit and return all matching messages")
+	return cmd
+}
+
+func backfillIndexesCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var batchSize int
+	cmd := &cobra.Command{
+		Use:   "backfill-indexes",
+		Short: "Rebuild mention and attachment indexes for existing messages",
+		Long: `Reparse stored rendered HTML in messages.content to rebuild:
+
+  • message_mentions  – @-mentions extracted from each message
+  • message_attachments – /user_uploads/ links and any inline text preview
+  • messages_fts.attachment_text – so attachment content participates in search
+
+Useful after a schema migration that introduced these tables when the archive
+already contained messages. Runs in batches (default 200 per transaction) and
+prints progress to stderr. Idempotent: running twice leaves the same result.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			ctx := cmd.Context()
+			if err := st.InitSchema(ctx); err != nil {
+				return err
+			}
+			return syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{
+				BatchSize: batchSize,
+			}, os.Stderr)
+		},
+	}
+	cmd.Flags().IntVar(&batchSize, "batch", 200, "number of messages per transaction")
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -485,6 +485,9 @@ Useful after a schema migration that introduced these tables when the archive
 already contained messages. Runs in batches (default 200 per transaction) and
 prints progress to stderr. Idempotent: running twice leaves the same result.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if batchSize <= 0 {
+				return fmt.Errorf("--batch must be positive")
+			}
 			cfg, err := loadCfg()
 			if err != nil {
 				return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -862,25 +862,26 @@ func (s *Store) Ping(ctx context.Context) error {
 
 // BackfillRow is a minimal row returned by MessageRowsForBackfill.
 type BackfillRow struct {
-	ID          int64
-	OrgID       int64
-	StreamID    int64
-	TopicID     int64
-	Timestamp   string
-	Content     string // raw rendered HTML
+	ID        int64
+	OrgID     int64
+	StreamID  int64
+	TopicID   int64
+	Timestamp string
+	Content   string // raw rendered HTML
 }
 
 // MessageRowsForBackfill streams a batch of message rows starting after
-// afterID (for pagination). It returns at most batchSize rows, ordered by id
-// ascending. The caller should call this repeatedly with the last returned ID
-// as afterID until an empty slice is returned.
-func (s *Store) MessageRowsForBackfill(ctx context.Context, afterID int64, batchSize int) ([]BackfillRow, error) {
+// afterID up to maxID inclusive (for snapshot-bounded pagination). It returns
+// at most batchSize rows, ordered by id ascending. The caller should call this
+// repeatedly with the last returned ID as afterID until an empty slice is
+// returned.
+func (s *Store) MessageRowsForBackfill(ctx context.Context, afterID, maxID int64, batchSize int) ([]BackfillRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, org_id, stream_id, topic_id, timestamp, content
 FROM messages
-WHERE id > ?
+WHERE id > ? AND id <= ?
 ORDER BY id ASC
-LIMIT ?`, afterID, batchSize)
+LIMIT ?`, afterID, maxID, batchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -984,10 +985,23 @@ WHERE m.id = ?`, r.ID,
 	return tx.Commit()
 }
 
+// MaxMessageID returns the highest message id currently in the archive. It is
+// used to bound long-running backfills to a stable initial snapshot.
+func (s *Store) MaxMessageID(ctx context.Context) (int64, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM messages`).Scan(&id)
+	return id, err
+}
+
 // CountMessages returns the total number of rows in the messages table.
 func (s *Store) CountMessages(ctx context.Context) (int64, error) {
+	return s.CountMessagesThroughID(ctx, 1<<63-1)
+}
+
+// CountMessagesThroughID returns the number of messages at or below maxID.
+func (s *Store) CountMessagesThroughID(ctx context.Context, maxID int64) (int64, error) {
 	var n int64
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages`).Scan(&n)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages WHERE id <= ?`, maxID).Scan(&n)
 	return n, err
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -860,6 +860,137 @@ func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
 
+// BackfillRow is a minimal row returned by MessageRowsForBackfill.
+type BackfillRow struct {
+	ID          int64
+	OrgID       int64
+	StreamID    int64
+	TopicID     int64
+	Timestamp   string
+	Content     string // raw rendered HTML
+}
+
+// MessageRowsForBackfill streams a batch of message rows starting after
+// afterID (for pagination). It returns at most batchSize rows, ordered by id
+// ascending. The caller should call this repeatedly with the last returned ID
+// as afterID until an empty slice is returned.
+func (s *Store) MessageRowsForBackfill(ctx context.Context, afterID int64, batchSize int) ([]BackfillRow, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, org_id, stream_id, topic_id, timestamp, content
+FROM messages
+WHERE id > ?
+ORDER BY id ASC
+LIMIT ?`, afterID, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []BackfillRow
+	for rows.Next() {
+		var r BackfillRow
+		if err := rows.Scan(&r.ID, &r.OrgID, &r.StreamID, &r.TopicID, &r.Timestamp, &r.Content); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UpsertDerivedIndexesWithFTS replaces the mention/attachment rows for a set of
+// messages and updates messages_fts attachment_text for those rows. It is
+// idempotent: the DELETE + INSERT pattern ensures running twice leaves the same
+// result. All changes for a batch land in a single transaction.
+//
+// indexer is called per-message to produce the derived Mention/Attachment
+// slices from the rendered HTML. Passing it as a callback keeps the store
+// import-free from the syncer/indexing package (avoids a circular dep).
+func (s *Store) UpsertDerivedIndexesWithFTS(ctx context.Context, rows []BackfillRow, indexer func(r BackfillRow) ([]Mention, []Attachment)) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		mentions, attachments := indexer(r)
+
+		// Replace existing derived rows for this message.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM message_mentions WHERE message_id = ?`, r.ID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("delete mentions for message %d: %w", r.ID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM message_attachments WHERE message_id = ?`, r.ID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("delete attachments for message %d: %w", r.ID, err)
+		}
+
+		for _, m := range mentions {
+			if m.Kind == "" {
+				m.Kind = "user"
+			}
+			if m.Timestamp == "" {
+				m.Timestamp = r.Timestamp
+			}
+			if _, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO message_mentions(
+	message_id, org_id, stream_id, topic_id, mentioned_user_id, mentioned_name, mention_kind, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				r.ID, r.OrgID, r.StreamID, r.TopicID, nullInt64IfZero(m.UserID), m.Name, m.Kind, m.Timestamp,
+			); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("insert mention for message %d: %w", r.ID, err)
+			}
+		}
+
+		for _, a := range attachments {
+			if a.Timestamp == "" {
+				a.Timestamp = r.Timestamp
+			}
+			if _, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO message_attachments(
+	message_id, org_id, stream_id, topic_id, url, file_name, title, content_type, text_content, indexed, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				r.ID, r.OrgID, r.StreamID, r.TopicID, a.URL, a.FileName, a.Title,
+				a.ContentType, nullIfEmpty(a.Text), boolToInt(a.Indexed), a.Timestamp,
+			); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("insert attachment for message %d: %w", r.ID, err)
+			}
+		}
+
+		// Refresh FTS reading content_text from the stored row.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM messages_fts WHERE rowid = ?`, r.ID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("delete fts for message %d: %w", r.ID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
+SELECT m.id, m.content_text,
+  COALESCE(t.name, ''),
+  COALESCE(u.full_name, ''),
+  COALESCE((SELECT group_concat(a.text_content, ' ')
+            FROM message_attachments a
+            WHERE a.message_id = m.id AND a.indexed = 1), '')
+FROM messages m
+LEFT JOIN topics t ON t.id = m.topic_id
+LEFT JOIN users u ON u.id = m.sender_id
+WHERE m.id = ?`, r.ID,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("reinsert fts for message %d: %w", r.ID, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// CountMessages returns the total number of rows in the messages table.
+func (s *Store) CountMessages(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages`).Scan(&n)
+	return n, err
+}
+
 func (s *Store) EnsureSystemUser(ctx context.Context, orgID int64, id int64, name string) error {
 	if id == 0 {
 		return nil

--- a/internal/store/store_messages_test.go
+++ b/internal/store/store_messages_test.go
@@ -358,3 +358,22 @@ func TestQueryMessages_SenderEscapesLikeWildcards(t *testing.T) {
 		t.Fatalf("expected only literal underscore sender, got %#v", rows)
 	}
 }
+
+func TestMessageRowsForBackfillBoundsToMaxID(t *testing.T) {
+	st := openTestStore(t)
+	defer st.Close()
+	seedDB(t, st)
+
+	rows, err := st.MessageRowsForBackfill(context.Background(), 0, 2000, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.ID > 2000 {
+			t.Fatalf("row %d is outside snapshot max id", row.ID)
+		}
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected bounded backfill rows")
+	}
+}

--- a/internal/syncer/backfill.go
+++ b/internal/syncer/backfill.go
@@ -35,7 +35,11 @@ func BackfillIndexes(ctx context.Context, st *store.Store, opts BackfillOptions,
 		batchSize = defaultBackfillBatch
 	}
 
-	total, err := st.CountMessages(ctx)
+	maxID, err := st.MaxMessageID(ctx)
+	if err != nil {
+		return fmt.Errorf("backfill: find max message id: %w", err)
+	}
+	total, err := st.CountMessagesThroughID(ctx, maxID)
 	if err != nil {
 		return fmt.Errorf("backfill: count messages: %w", err)
 	}
@@ -44,7 +48,7 @@ func BackfillIndexes(ctx context.Context, st *store.Store, opts BackfillOptions,
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(w, "backfill-indexes: %d messages to process (batch=%d)\n", total, batchSize)
+	_, _ = fmt.Fprintf(w, "backfill-indexes: %d messages to process through id=%d (batch=%d)\n", total, maxID, batchSize)
 	start := time.Now()
 
 	indexer := func(r store.BackfillRow) ([]store.Mention, []store.Attachment) {
@@ -54,7 +58,7 @@ func BackfillIndexes(ctx context.Context, st *store.Store, opts BackfillOptions,
 	var processed int64
 	var afterID int64
 	for {
-		batch, err := st.MessageRowsForBackfill(ctx, afterID, batchSize)
+		batch, err := st.MessageRowsForBackfill(ctx, afterID, maxID, batchSize)
 		if err != nil {
 			return fmt.Errorf("backfill: fetch batch after id=%d: %w", afterID, err)
 		}

--- a/internal/syncer/backfill.go
+++ b/internal/syncer/backfill.go
@@ -1,0 +1,78 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+const defaultBackfillBatch = 200
+
+// BackfillOptions controls the backfill-indexes command.
+type BackfillOptions struct {
+	// BatchSize is the number of messages processed per transaction.
+	// Defaults to 200.
+	BatchSize int
+}
+
+// BackfillIndexer rebuilds message_mentions, message_attachments, and the
+// attachment_text column in messages_fts from the stored rendered HTML in
+// messages.content. It processes messages in ascending ID order in batches so
+// large archives neither appear hung nor hold one giant transaction.
+//
+// The function is idempotent: it deletes and reinserts derived rows on each
+// pass, so running twice leaves the same result.
+func BackfillIndexes(ctx context.Context, st *store.Store, opts BackfillOptions, w io.Writer) error {
+	if w == nil {
+		w = os.Stderr
+	}
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBackfillBatch
+	}
+
+	total, err := st.CountMessages(ctx)
+	if err != nil {
+		return fmt.Errorf("backfill: count messages: %w", err)
+	}
+	if total == 0 {
+		_, _ = fmt.Fprintln(w, "backfill-indexes: no messages in archive, nothing to do")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(w, "backfill-indexes: %d messages to process (batch=%d)\n", total, batchSize)
+	start := time.Now()
+
+	indexer := func(r store.BackfillRow) ([]store.Mention, []store.Attachment) {
+		return parseMessageIndexables(r.ID, r.OrgID, r.StreamID, r.TopicID, r.Timestamp, r.Content)
+	}
+
+	var processed int64
+	var afterID int64
+	for {
+		batch, err := st.MessageRowsForBackfill(ctx, afterID, batchSize)
+		if err != nil {
+			return fmt.Errorf("backfill: fetch batch after id=%d: %w", afterID, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		if err := st.UpsertDerivedIndexesWithFTS(ctx, batch, indexer); err != nil {
+			return fmt.Errorf("backfill: upsert derived indexes (batch starting id=%d): %w", batch[0].ID, err)
+		}
+
+		processed += int64(len(batch))
+		afterID = batch[len(batch)-1].ID
+		_, _ = fmt.Fprintf(w, "backfill-indexes: %d/%d messages done (last id=%d, elapsed=%s)\n",
+			processed, total, afterID, time.Since(start).Round(time.Millisecond))
+	}
+
+	_, _ = fmt.Fprintf(w, "backfill-indexes: complete – %d messages processed in %s\n",
+		processed, time.Since(start).Round(time.Millisecond))
+	return nil
+}

--- a/internal/syncer/backfill_test.go
+++ b/internal/syncer/backfill_test.go
@@ -1,0 +1,219 @@
+package syncer_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+	"github.com/FtlC-ian/zulcrawl/internal/syncer"
+)
+
+// openTestStore opens a fresh SQLite DB in a temp dir with schema applied.
+func openTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://z.example.com", "TestOrg"); err != nil {
+		t.Fatalf("UpsertOrganization: %v", err)
+	}
+	if err := st.UpsertStream(ctx, store.Stream{ID: 10, OrgID: 1, Name: "general"}); err != nil {
+		t.Fatalf("UpsertStream: %v", err)
+	}
+	if err := st.UpsertUser(ctx, store.User{ID: 20, OrgID: 1, FullName: "Alice"}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	return st
+}
+
+// queryCount runs a COUNT(*) SQL query via the store's raw Query method.
+func queryCount(t *testing.T, st *store.Store, ctx context.Context, query string) int {
+	t.Helper()
+	rows, err := st.Query(ctx, query)
+	if err != nil {
+		t.Fatalf("queryCount(%q): %v", query, err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatalf("queryCount(%q): no rows returned", query)
+	}
+	var n int
+	if err := rows.Scan(&n); err != nil {
+		t.Fatalf("queryCount(%q) scan: %v", query, err)
+	}
+	return n
+}
+
+// seedOldMessage inserts a message without any derived indexes (simulates
+// a pre-Phase-2 archive row).
+func seedOldMessage(t *testing.T, st *store.Store, id int64, html string) {
+	t.Helper()
+	ctx := context.Background()
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	if err := st.UpsertMessage(ctx, store.Message{
+		ID:          id,
+		OrgID:       1,
+		StreamID:    10,
+		TopicID:     topicID,
+		SenderID:    20,
+		Content:     html,
+		ContentText: "content text",
+		Timestamp:   "2026-01-01T00:00:00Z",
+		// Intentionally NO Mentions or Attachments (old-style row).
+	}); err != nil {
+		t.Fatalf("UpsertMessage %d: %v", id, err)
+	}
+}
+
+// TestBackfillIndexes_OldStyleDB confirms that BackfillIndexes populates
+// message_mentions and message_attachments for messages that were inserted
+// before the indexing logic existed.
+func TestBackfillIndexes_OldStyleDB(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	// An old message that contains a @-mention and an attachment link in HTML.
+	const msgHTML = `<p>Hey <span class="user-mention" data-user-id="42">@Bob</span>, see <a class="message_inline_ref" href="/user_uploads/1/ab/notes.txt">notes.txt</a></p>`
+	seedOldMessage(t, st, 1001, msgHTML)
+
+	// Verify no derived rows exist before backfill.
+	mentionsBefore := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id=1001`)
+	attachmentsBefore := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_attachments WHERE message_id=1001`)
+	if mentionsBefore != 0 {
+		t.Fatalf("expected 0 mentions before backfill, got %d", mentionsBefore)
+	}
+	if attachmentsBefore != 0 {
+		t.Fatalf("expected 0 attachments before backfill, got %d", attachmentsBefore)
+	}
+
+	// Run backfill.
+	if err := syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{BatchSize: 50}, os.Stderr); err != nil {
+		t.Fatalf("BackfillIndexes: %v", err)
+	}
+
+	// Verify derived rows now exist.
+	mentionsAfter := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id=1001 AND mentioned_user_id=42`)
+	attachmentsAfter := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_attachments WHERE message_id=1001 AND file_name='notes.txt'`)
+	if mentionsAfter != 1 {
+		t.Fatalf("expected 1 mention after backfill, got %d", mentionsAfter)
+	}
+	if attachmentsAfter != 1 {
+		t.Fatalf("expected 1 attachment after backfill, got %d", attachmentsAfter)
+	}
+}
+
+// TestBackfillIndexes_Idempotent confirms that running BackfillIndexes twice
+// does not duplicate rows.
+func TestBackfillIndexes_Idempotent(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	const msgHTML = `<p><span class="user-mention" data-user-id="99">@Carol</span></p>`
+	seedOldMessage(t, st, 2001, msgHTML)
+
+	for i := 0; i < 2; i++ {
+		if err := syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{BatchSize: 50}, os.Stderr); err != nil {
+			t.Fatalf("BackfillIndexes (run %d): %v", i+1, err)
+		}
+	}
+
+	count := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id=2001`)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 mention after 2 backfill runs (idempotence), got %d", count)
+	}
+}
+
+// TestBackfillIndexes_AttachmentFTSSearch confirms that after backfill, a
+// search for text that appears only in attachment_text returns the right message.
+func TestBackfillIndexes_AttachmentFTSSearch(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	// The message body itself does not contain "secretword"; it only appears
+	// in the inline text near an attachment link.
+	const msgHTML = `<p>See attachment</p><p><a class="message_inline_ref" href="/user_uploads/1/xy/report.txt">secretword report text</a></p>`
+	seedOldMessage(t, st, 3001, msgHTML)
+
+	// Before backfill, attachment_text in FTS is empty – search returns nothing.
+	hitsBefore, err := st.Search(ctx, "secretword", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search before backfill: %v", err)
+	}
+	if len(hitsBefore) != 0 {
+		t.Fatalf("expected 0 hits before backfill, got %d", len(hitsBefore))
+	}
+
+	// Run backfill.
+	if err := syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{BatchSize: 50}, os.Stderr); err != nil {
+		t.Fatalf("BackfillIndexes: %v", err)
+	}
+
+	// After backfill, the attachment text should be searchable.
+	hitsAfter, err := st.Search(ctx, "secretword", "", false, 10)
+	if err != nil {
+		t.Fatalf("Search after backfill: %v", err)
+	}
+	found := false
+	for _, h := range hitsAfter {
+		if strings.Contains(h.Snippet, "secretword") || h.MessageID == 3001 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected to find message 3001 in search results after backfill, hits=%+v", hitsAfter)
+	}
+}
+
+// TestBackfillIndexes_EmptyDB confirms backfill on an empty archive does not error.
+func TestBackfillIndexes_EmptyDB(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+	if err := syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{BatchSize: 50}, os.Stderr); err != nil {
+		t.Fatalf("BackfillIndexes on empty DB: %v", err)
+	}
+}
+
+// TestBackfillIndexes_MultipleMessages confirms batching works across several messages.
+func TestBackfillIndexes_MultipleMessages(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	// Seed 5 messages – use a small batch size of 2 to exercise pagination.
+	for i := int64(1); i <= 5; i++ {
+		html := `<p><span class="user-mention" data-user-id="99">@Carol</span></p>`
+		seedOldMessage(t, st, 4000+i, html)
+	}
+
+	if err := syncer.BackfillIndexes(ctx, st, syncer.BackfillOptions{BatchSize: 2}, os.Stderr); err != nil {
+		t.Fatalf("BackfillIndexes: %v", err)
+	}
+
+	// Confirm no messages were lost.
+	total, err := st.CountMessages(ctx)
+	if err != nil {
+		t.Fatalf("CountMessages: %v", err)
+	}
+	if total != 5 {
+		t.Fatalf("expected 5 messages after backfill, got %d", total)
+	}
+
+	// Each message should have exactly 1 mention.
+	totalMentions := queryCount(t, st, ctx, `SELECT COUNT(*) FROM message_mentions WHERE message_id BETWEEN 4001 AND 4005`)
+	if totalMentions != 5 {
+		t.Fatalf("expected 5 total mentions (1 per message), got %d", totalMentions)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #10.

Adds `zulcrawl backfill-indexes` to rebuild derived indexes for existing archive rows that predate the Phase 2 mention/attachment indexing work.

## What changed

### New command
```
zulcrawl backfill-indexes [--batch N]
```
- Reparses `messages.content` (stored rendered HTML) for every message in the archive
- Rebuilds `message_mentions` and `message_attachments` from the HTML
- Refreshes `messages_fts.attachment_text` so attachment content participates in FTS search
- Runs in batches (default 200 per transaction) so large archives don't block
- Prints progress to stderr
- **Idempotent**: running twice leaves the same result

### Files
- `internal/store/store.go` — three new exported methods:
  - `MessageRowsForBackfill`: paginated batch reader using cursor (afterID)
  - `UpsertDerivedIndexesWithFTS`: idempotent batch upsert of derived rows + FTS refresh in one transaction
  - `CountMessages`: total message count for progress display
- `internal/syncer/backfill.go` — `BackfillIndexes` orchestrator
- `internal/cli/root.go` — `backfill-indexes` subcommand with `--batch` flag
- `internal/syncer/backfill_test.go` — 5 tests covering old-style DB, idempotence, attachment FTS search, empty DB, and multi-batch pagination

## Tests
```
ok  github.com/FtlC-ian/zulcrawl/internal/syncer  (all pass, including -race)
```

## Operational notes

Run this once after upgrading an existing archive to Phase 2 schema:

```sh
zulcrawl backfill-indexes
# or with a custom batch size for very large archives:
zulcrawl backfill-indexes --batch 500
```

Progress is printed to stderr. The command is safe to re-run (idempotent).

Source message rows are never modified; only `message_mentions`, `message_attachments`, and `messages_fts` are updated.