### PR TITLE
fix: post-merge reliability and docs follow-ups (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,29 @@
 - Cobra CLI commands:
   - `init`
   - `doctor`
-  - `sync --full --streams --since`
+  - `sync --full --streams --since [--quiet]`
   - `search`
   - `topics`
   - `stats`
   - `sql`
+  - `messages` — direct archive slice queries (see below)
+  - `backfill-indexes` — rebuild mention/attachment indexes for existing messages
 - Syncer with parallel stream workers and incremental sync (`sync_state`)
 - HTML-to-text conversion for indexing
 - Search ranking with FTS BM25, resolved-topic boost, and recency boost
+- Mention and attachment indexes parsed from rendered HTML
+
+## Attachment indexing — current scope
+
+Attachment indexing covers **text already present in the Zulip-rendered HTML** of
+each message — inline previews and short snippets that Zulip embeds in the
+rendered `<div class="message_inline_ref">` block.  It does **not** fetch or
+parse the actual uploaded file contents (PDFs, images, Office documents, etc.).
+For text-heavy attachments the best coverage comes from users quoting or
+summarising content in the message body itself.
+
+Full file-content extraction (downloading from `/user_uploads/…` and parsing
+the file bytes) is a planned future enhancement and is **not implemented**.
 
 ## Build
 
@@ -68,6 +83,9 @@ zulcrawl sync --streams general,engineering
 # Sync only messages from date onward (YYYY-MM-DD)
 zulcrawl sync --since 2026-01-01
 
+# Sync silently (suppress progress lines, show only final summary or errors)
+zulcrawl sync --quiet
+
 # Search
 zulcrawl search "database migration"
 zulcrawl search --stream engineering --resolved "deploy script"
@@ -81,6 +99,58 @@ zulcrawl stats
 
 # Raw SQL
 zulcrawl sql "SELECT stream_id, COUNT(*) FROM messages GROUP BY stream_id ORDER BY 2 DESC LIMIT 10"
+```
+
+## messages command
+
+`zulcrawl messages` queries the local archive without hitting the Zulip API.
+At least one narrowing filter is required to prevent accidental full-archive dumps.
+
+**Flags**
+
+| Flag | Description |
+|------|-------------|
+| `--stream NAME` | Filter by stream name (exact match) |
+| `--topic NAME` | Filter by topic name (exact match) |
+| `--sender NAME` | Filter by sender full name (substring match) |
+| `--since DATE` | Only messages at or after this time (RFC3339 or `YYYY-MM-DD`) |
+| `--until DATE` | Only messages at or before this time (RFC3339 or `YYYY-MM-DD`) |
+| `--days N` | Only messages from the last N days |
+| `--hours N` | Only messages from the last N hours |
+| `--last N` | Return the N most recent messages (oldest-first output) |
+| `--limit N` | Maximum messages to return (default 200) |
+| `--all` | Remove safety limit and return all matching messages |
+
+**Examples**
+
+```bash
+# Last 7 days in the #general stream
+zulcrawl messages --stream general --days 7
+
+# All messages in a specific topic
+zulcrawl messages --stream engineering --topic "Q2 roadmap"
+
+# Messages from a specific sender since a date
+zulcrawl messages --sender "Alice" --since 2026-01-01
+
+# Last 50 messages across the entire archive
+zulcrawl messages --last 50
+
+# Messages in the last 4 hours across all streams
+zulcrawl messages --hours 4
+
+# Combined: sender + date range, higher limit
+zulcrawl messages --stream dev --sender "Bob" --since 2026-03-01 --until 2026-03-31 --limit 500
+
+# Remove the safety cap entirely (use with care on large archives)
+zulcrawl messages --stream general --days 365 --all
+```
+
+Output format per message:
+```
+[YYYY-MM-DD HH:MM:SS] #stream > topic | Sender Name
+  message content text...
+
 ```
 
 ## Notes

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -147,6 +147,7 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	var full bool
 	var since string
 	var streams string
+	var quiet bool
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync streams/messages from Zulip",
@@ -158,6 +159,17 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 			if err := cfg.ValidateAuth(); err != nil {
 				return err
 			}
+
+			// Acquire the exclusive lock immediately after auth validation and
+			// before any DB open / migration work, so two concurrent sync
+			// invocations cannot race on schema migration, reindex, or setup.
+			lockPath := cfg.DBPath() + ".lock"
+			l, err := lock.Acquire(lockPath)
+			if err != nil {
+				return err
+			}
+			defer l.Release()
+
 			ctx := cmd.Context()
 			st, err := store.Open(cfg.DBPath())
 			if err != nil {
@@ -168,17 +180,7 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 				return err
 			}
 
-			// Acquire an exclusive lock so two concurrent sync processes do not
-			// write the same archive simultaneously.
-			lockPath := cfg.DBPath() + ".lock"
-			l, err := lock.Acquire(lockPath)
-			if err != nil {
-				return err
-			}
-			defer l.Release()
-
 			api := zulip.NewClient(cfg.Zulip.URL, cfg.Zulip.Email, cfg.Zulip.APIKey)
-			sy := syncer.New(cfg, api, st)
 			var include []string
 			if streams != "" {
 				for _, s := range strings.Split(streams, ",") {
@@ -195,6 +197,13 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 				since = since + "T00:00:00Z"
 			}
 
+			var sy *syncer.Syncer
+			if quiet {
+				sy = syncer.NewWithLogger(cfg, api, st, nil)
+			} else {
+				sy = syncer.New(cfg, api, st)
+			}
+
 			start := time.Now()
 			if err := sy.Sync(ctx, syncer.Options{Full: full, Streams: include, Since: since}); err != nil {
 				return err
@@ -206,6 +215,7 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	cmd.Flags().BoolVar(&full, "full", false, "full backfill")
 	cmd.Flags().StringVar(&streams, "streams", "", "comma-separated stream names")
 	cmd.Flags().StringVar(&since, "since", "", "only include messages since date (YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output (only print final summary or errors)")
 	return cmd
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -293,6 +293,26 @@ email=excluded.email, full_name=excluded.full_name, is_bot=excluded.is_bot, avat
 	return err
 }
 
+// EnsureMessageSender upserts a user record derived from message metadata
+// (sender_id + sender_full_name). Unlike UpsertUser it preserves existing
+// non-empty fields (email, avatar_url, is_bot) so that a full-roster sync
+// does not get overwritten by the sparse data carried in message headers.
+// Only full_name is always refreshed because it is the only field reliably
+// present in every message.
+func (s *Store) EnsureMessageSender(ctx context.Context, u User) error {
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO users(id, org_id, email, full_name, is_bot, avatar_url, synced_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  full_name = excluded.full_name,
+  email     = CASE WHEN excluded.email     != '' THEN excluded.email     ELSE email     END,
+  avatar_url= CASE WHEN excluded.avatar_url!= '' THEN excluded.avatar_url ELSE avatar_url END,
+  is_bot    = CASE WHEN excluded.is_bot    != 0  THEN excluded.is_bot    ELSE is_bot    END,
+  synced_at = excluded.synced_at
+`, u.ID, u.OrgID, u.Email, u.FullName, boolToInt(u.IsBot), u.AvatarURL, now())
+	return err
+}
+
 func topicResolved(name string) bool {
 	t := strings.TrimSpace(name)
 	return strings.HasPrefix(t, "✔") || strings.HasPrefix(strings.ToLower(t), "[resolved]")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -120,3 +120,66 @@ func TestUpsertMessageReplacesMentionAndAttachmentRows(t *testing.T) {
 		t.Fatalf("new attachment text hits = %d, want 1", len(hits))
 	}
 }
+
+func TestEnsureMessageSenderPreservesExistingFields(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	// First insert a full user record via UpsertUser (as the roster sync would).
+	if err := st.UpsertUser(ctx, User{
+		ID:        50,
+		OrgID:     1,
+		Email:     "alice@example.com",
+		FullName:  "Alice Roster",
+		IsBot:     false,
+		AvatarURL: "https://example.com/avatar.png",
+	}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+
+	// Now simulate the message-sender auto-upsert with sparse data (no email/avatar).
+	if err := st.EnsureMessageSender(ctx, User{
+		ID:       50,
+		OrgID:    1,
+		FullName: "Alice Updated Name",
+		// Email, AvatarURL, IsBot are zero — should NOT overwrite existing values.
+	}); err != nil {
+		t.Fatalf("EnsureMessageSender: %v", err)
+	}
+
+	var email, avatar, fullName string
+	var isBot int
+	if err := st.db.QueryRowContext(ctx, `SELECT email, full_name, is_bot, avatar_url FROM users WHERE id=50`).Scan(&email, &fullName, &isBot, &avatar); err != nil {
+		t.Fatalf("query user: %v", err)
+	}
+	if fullName != "Alice Updated Name" {
+		t.Errorf("full_name = %q, want %q", fullName, "Alice Updated Name")
+	}
+	if email != "alice@example.com" {
+		t.Errorf("email = %q, want preserved %q", email, "alice@example.com")
+	}
+	if avatar != "https://example.com/avatar.png" {
+		t.Errorf("avatar_url = %q, want preserved", avatar)
+	}
+	if isBot != 0 {
+		t.Errorf("is_bot = %d, want 0 (preserved)", isBot)
+	}
+}
+
+func TestEnsureMessageSenderInsertsNewUser(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	// A user not in the roster yet — only message metadata available.
+	if err := st.EnsureMessageSender(ctx, User{
+		ID:       99,
+		OrgID:    1,
+		FullName: "Ghost Bot",
+	}); err != nil {
+		t.Fatalf("EnsureMessageSender: %v", err)
+	}
+
+	var fullName string
+	if err := st.db.QueryRowContext(ctx, `SELECT full_name FROM users WHERE id=99`).Scan(&fullName); err != nil {
+		t.Fatalf("query user: %v", err)
+	}
+	if fullName != "Ghost Bot" {
+		t.Errorf("full_name = %q, want %q", fullName, "Ghost Bot")
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -208,8 +208,10 @@ func (s *Syncer) syncStream(ctx context.Context, st zulip.Stream, opts Options) 
 		// not return bots, system users, or deactivated accounts, but every
 		// message carries sender_id + sender_full_name, so we can ensure the
 		// FK target exists before inserting the message.
+		// EnsureMessageSender preserves richer fields (email/avatar/is_bot)
+		// that were populated by the full roster sync.
 		for _, m := range resp.Messages {
-			if err := s.store.UpsertUser(ctx, store.User{
+			if err := s.store.EnsureMessageSender(ctx, store.User{
 				ID:       m.SenderID,
 				OrgID:    s.orgID,
 				FullName: m.SenderFullName,
@@ -347,7 +349,7 @@ func (s *Syncer) syncPrivateMessages(ctx context.Context, opts Options) error {
 		s.logger.log("private messages: page %d – %d messages (anchor=%s)", pageNum, len(resp.Messages), anchor)
 
 		for _, m := range resp.Messages {
-			if err := s.store.UpsertUser(ctx, store.User{
+			if err := s.store.EnsureMessageSender(ctx, store.User{
 				ID:       m.SenderID,
 				OrgID:    s.orgID,
 				FullName: m.SenderFullName,


### PR DESCRIPTION
Closes #11

## Summary

Five focused improvements addressing reliability and documentation gaps.

### 1. Move sync lock earlier
The exclusive lock in `zulcrawl sync` now acquires immediately after config/auth validation and **before** `store.Open` / `InitSchema`, preventing two concurrent invocations from racing on schema migration, FTS reindex, or initial setup.

### 2. Preserve richer user fields on message-sender fallback
Added `EnsureMessageSender` to the store, which:
- Always refreshes `full_name` (reliably present in message metadata)
- Preserves existing non-empty `email`, `avatar_url`, and `is_bot` values instead of blanking them

The syncer now calls `EnsureMessageSender` instead of `UpsertUser` for the auto-upsert path, so a roster sync cannot be silently overwritten by sparse message-metadata upserts.

### 3. Document `zulcrawl messages`
README now includes a full flag table and worked examples for all filters: `--stream`, `--topic`, `--sender`, `--since`, `--until`, `--days`, `--hours`, `--last`, `--limit`, and `--all`.

### 4. Add `--quiet` to `zulcrawl sync`
Passes `nil` to `NewWithLogger` to suppress per-page progress lines. The final timing summary line (`sync complete in ...`) is always printed regardless of `--quiet`.

### 5. Document attachment indexing limitation
README now clearly states that attachment indexing covers only text already present in Zulip-rendered HTML (inline previews) and does not fetch or parse uploaded file contents.

## Verification
```
go build ./...        ✓
go test ./...         ✓ (all packages)
go test -race ./...   ✓
govulncheck ./...      ✓ No vulnerabilities found
```

## Deferred
- **backfill-indexes docs** in README: PR #12 (`backfill-indexes` command) is still open; a small mention will be easy to add once that merges.
- Full file-content extraction for attachments: documented as future work.