### PR TITLE
fix: lock archive during backfill

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -502,6 +502,13 @@ prints progress to stderr. Idempotent: running twice leaves the same result.`,
 			if err != nil {
 				return err
 			}
+			lockPath := cfg.DBPath() + ".lock"
+			l, err := lock.Acquire(lockPath)
+			if err != nil {
+				return err
+			}
+			defer l.Release()
+
 			st, err := store.Open(cfg.DBPath())
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary
- acquire the same archive lock for backfill-indexes before opening/migrating the DB
- prevents concurrent sync/backfill processes from interleaving writes to derived indexes and FTS

## Tests
- go test ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- go build ./...

Follow-up from Codex review on PR #12.