### PR TITLE
feat: phase 2 chunk 4 – topic-level hybrid search (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
   - `doctor`
   - `sync --full --streams --since [--quiet]`
   - `search`
-  - `topics`
+  - `topics` — list topics or topic-level hybrid search
+  - `topics search` — hybrid search: FTS on topic names + message content (see below)
   - `stats`
   - `sql`
   - `messages` — direct archive slice queries (see below)
@@ -20,6 +21,7 @@
 - Syncer with parallel stream workers and incremental sync (`sync_state`)
 - HTML-to-text conversion for indexing
 - Search ranking with FTS BM25, resolved-topic boost, and recency boost
+- Topic-level hybrid search: two-leg FTS (topic names + message content) with activity/recency scoring
 - Mention and attachment indexes parsed from rendered HTML
 
 ## Attachment indexing — current scope
@@ -94,11 +96,53 @@ zulcrawl search --stream engineering --resolved "deploy script"
 zulcrawl topics --stream engineering
 zulcrawl topics --unresolved
 
+# Topic-level hybrid search (FTS on topic names + message content)
+# Finds topics whose name or messages match the query
+zulcrawl topics search "database migration"
+zulcrawl topics search --stream engineering "deploy script"
+zulcrawl topics search --unresolved --limit 10 "onboarding"
+
 # Stats
 zulcrawl stats
 
 # Raw SQL
 zulcrawl sql "SELECT stream_id, COUNT(*) FROM messages GROUP BY stream_id ORDER BY 2 DESC LIMIT 10"
+```
+
+## topics search command
+
+`zulcrawl topics search <query>` performs a hybrid topic-level search over the
+local archive. It runs two legs:
+
+1. **Topic-name FTS** (`topics_fts`) — finds topics whose name matches the query.
+2. **Message-content FTS** (`messages_fts`) aggregated by topic — finds topics
+   that contain relevant messages.
+
+Results from both legs are merged and de-duplicated by topic ID, then scored:
+
+| Signal | Weight |
+|--------|--------|
+| BM25 relevance (best of name/message leg) | base |
+| Activity bonus: log₂(1 + message_count) × 0.1 | up to ~0.7 for large topics |
+| Recency decay: 0.5 / (1 + days_since_last_msg / 30) | 0–0.5 |
+| Resolved bonus | +0.15 |
+
+**No remote embedding APIs are called.** This is a local FTS/hybrid approach.
+Vector-embedding provider integration is deferred to a future chunk (issue #9).
+
+**Flags**
+
+| Flag | Description |
+|------|-------------|
+| `--stream NAME` | Filter by stream name |
+| `--unresolved` | Exclude resolved topics |
+| `--limit N` | Maximum topics to return (default 20) |
+
+**Output format**
+
+```
+#stream > topic name [resolved] (N msgs, last YYYY-MM-DD)
+  …best matching message snippet…
 ```
 
 ## messages command
@@ -157,4 +201,4 @@ Output format per message:
 
 - Uses `modernc.org/sqlite` (pure Go, no CGO)
 - Current implementation focuses on core mirror/search flow
-- Planned later (per spec): tail/event queue, MCP server, semantic search, summarization, Q&A extraction
+- Planned later (per spec): tail/event queue, MCP server, vector-embedding semantic search (pluggable provider, off by default), summarization, Q&A extraction

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -258,7 +258,7 @@ func topicsCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "topics",
-		Short: "List topics with stats",
+		Short: "List topics or search topics by content",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadCfg()
 			if err != nil {
@@ -286,6 +286,73 @@ func topicsCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	cmd.Flags().StringVar(&stream, "stream", "", "stream name")
 	cmd.Flags().BoolVar(&unresolved, "unresolved", false, "only unresolved topics")
 	cmd.Flags().IntVar(&limit, "limit", 100, "row limit")
+	cmd.AddCommand(topicsSearchCmd(loadCfg))
+	return cmd
+}
+
+func topicsSearchCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var stream string
+	var unresolved bool
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: "Hybrid topic-level search (FTS on topic names + message content)",
+		Long: `Search topics by name and by the content of their messages.
+
+Results are ranked by:
+  - FTS relevance (BM25) on topic name and/or message text
+  - Activity bonus: more messages → slightly higher rank
+  - Recency: recently-active topics rank higher
+  - Resolved bonus: resolved topics get a small lift
+
+This is a purely local FTS/hybrid search. No remote embedding APIs are called.
+Embedding-provider integration is left for a future chunk (see issue #9).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			hits, err := st.SearchTopics(cmd.Context(), store.TopicSearchOptions{
+				Query:          args[0],
+				Stream:         stream,
+				Limit:          limit,
+				OnlyUnresolved: unresolved,
+			})
+			if err != nil {
+				return err
+			}
+			if len(hits) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No topics found.")
+				return nil
+			}
+			for _, h := range hits {
+				res := ""
+				if h.Resolved {
+					res = " [resolved]"
+				}
+				lastAt := h.LastMessageAt
+				if t, err2 := time.Parse(time.RFC3339, h.LastMessageAt); err2 == nil {
+					lastAt = t.Format("2006-01-02")
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "#%s > %s%s (%d msgs, last %s)\n",
+					h.StreamName, h.TopicName, res, h.MessageCount, lastAt)
+				if h.BestSnippet != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", h.BestSnippet)
+				}
+				fmt.Fprintln(cmd.OutOrStdout())
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&stream, "stream", "", "filter by stream name")
+	cmd.Flags().BoolVar(&unresolved, "unresolved", false, "only unresolved topics")
+	cmd.Flags().IntVar(&limit, "limit", 20, "max topics to return")
 	return cmd
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -600,6 +602,226 @@ type SearchHit struct {
 	SenderName string
 	Snippet    string
 	Rank       float64
+}
+
+// TopicSearchHit is a single result from a topic-level search.
+type TopicSearchHit struct {
+	TopicID      int64
+	StreamName   string
+	TopicName    string
+	Resolved     bool
+	MessageCount int64
+	LastMessageAt  string
+	FirstMessageAt string
+	// BestSnippet is a representative snippet from the best-matching message.
+	BestSnippet string
+	// Rank is the combined relevance score (higher = better).
+	Rank float64
+}
+
+// TopicSearchOptions controls the topic-level search.
+type TopicSearchOptions struct {
+	Query  string
+	Stream string
+	Limit  int
+	// OnlyUnresolved excludes resolved topics.
+	OnlyUnresolved bool
+}
+
+// SearchTopics performs a hybrid topic-level search.
+//
+// It runs two legs:
+//  1. FTS on topic names (topics_fts) — catches topics whose title contains
+//     the query terms.
+//  2. FTS on message content (messages_fts) grouped by topic — catches topics
+//     discussed in messages matching the query.
+//
+// Results from both legs are merged and de-duplicated by topic ID, then ranked
+// by: BM25 relevance + log2(message_count) activity bonus + recency decay +
+// resolved bonus (+0.15).
+//
+// No remote embedding APIs are called. This is a purely local hybrid/FTS
+// approach; a pluggable vector-embedding layer is left for a future chunk.
+func (s *Store) SearchTopics(ctx context.Context, opts TopicSearchOptions) ([]TopicSearchHit, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+	if opts.Query == "" {
+		return nil, fmt.Errorf("query must not be empty")
+	}
+
+	// map from topicID → working result
+	type entry struct {
+		TopicSearchHit
+		nameScore    float64
+		contentScore float64
+	}
+	seen := map[int64]*entry{}
+
+	// ── Leg 1: topic-name FTS ────────────────────────────────────────────────
+	// Search topics_fts for name matches. We fetch raw bm25 (negated) and
+	// join topic metadata. We pull up to 4× the limit to have headroom after
+	// merge.
+	nameQ := `
+SELECT t.id, st.name, t.name, t.resolved, t.message_count,
+       COALESCE(t.last_message_at,''), COALESCE(t.first_message_at,''),
+       -bm25(topics_fts) AS bm25_score
+FROM topics_fts
+JOIN topics t ON t.id = topics_fts.rowid
+JOIN streams st ON st.id = t.stream_id
+WHERE topics_fts MATCH ?`
+	nameArgs := []any{opts.Query}
+	if opts.Stream != "" {
+		nameQ += " AND st.name = ?"
+		nameArgs = append(nameArgs, opts.Stream)
+	}
+	if opts.OnlyUnresolved {
+		nameQ += " AND t.resolved = 0"
+	}
+	nameQ += " ORDER BY bm25_score DESC LIMIT ?"
+	nameArgs = append(nameArgs, opts.Limit*4)
+
+	nameRows, err := s.db.QueryContext(ctx, nameQ, nameArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("topics_fts search: %w", err)
+	}
+	defer nameRows.Close()
+	for nameRows.Next() {
+		var e entry
+		var resolved int
+		if err := nameRows.Scan(
+			&e.TopicID, &e.StreamName, &e.TopicName,
+			&resolved, &e.MessageCount,
+			&e.LastMessageAt, &e.FirstMessageAt,
+			&e.nameScore,
+		); err != nil {
+			return nil, err
+		}
+		e.Resolved = resolved == 1
+		seen[e.TopicID] = &e
+	}
+	if err := nameRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// ── Leg 2: message-content FTS, grouped by topic ─────────────────────────
+	// bm25() is an FTS5 auxiliary function that can only be used in ORDER BY
+	// (or scalar position) of a direct FTS query — not inside MIN() / GROUP BY.
+	// We therefore fetch individual rows ordered by relevance and aggregate by
+	// topic in Go, keeping only the best score and first snippet per topic.
+	contentQ := `
+SELECT t.id, st.name, t.name, t.resolved, t.message_count,
+       COALESCE(t.last_message_at,''), COALESCE(t.first_message_at,''),
+       -bm25(messages_fts) AS bm25_score,
+       snippet(messages_fts, 0, '', '', ' … ', 20)
+FROM messages_fts
+JOIN messages m ON m.id = messages_fts.rowid
+JOIN topics t ON t.id = m.topic_id
+JOIN streams st ON st.id = m.stream_id
+WHERE messages_fts MATCH ?`
+	contentArgs := []any{opts.Query}
+	if opts.Stream != "" {
+		contentQ += " AND st.name = ?"
+		contentArgs = append(contentArgs, opts.Stream)
+	}
+	if opts.OnlyUnresolved {
+		contentQ += " AND t.resolved = 0"
+	}
+	contentQ += " ORDER BY bm25(messages_fts) LIMIT ?"
+	contentArgs = append(contentArgs, opts.Limit*8)
+
+	contentRows, err := s.db.QueryContext(ctx, contentQ, contentArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("messages_fts topic search: %w", err)
+	}
+	defer contentRows.Close()
+	for contentRows.Next() {
+		var topicID int64
+		var streamName, topicName, lastAt, firstAt, snippet string
+		var resolved int
+		var msgCount int64
+		var contentScore float64
+		if err := contentRows.Scan(
+			&topicID, &streamName, &topicName,
+			&resolved, &msgCount,
+			&lastAt, &firstAt,
+			&contentScore, &snippet,
+		); err != nil {
+			return nil, err
+		}
+		if existing, ok := seen[topicID]; ok {
+			// Keep the best (highest) content score seen for this topic.
+			if contentScore > existing.contentScore {
+				existing.contentScore = contentScore
+			}
+			// First snippet wins (rows are ordered best-first).
+			if existing.BestSnippet == "" && snippet != "" {
+				existing.BestSnippet = snippet
+			}
+		} else {
+			e := &entry{
+				TopicSearchHit: TopicSearchHit{
+					TopicID:        topicID,
+					StreamName:     streamName,
+					TopicName:      topicName,
+					Resolved:       resolved == 1,
+					MessageCount:   msgCount,
+					LastMessageAt:  lastAt,
+					FirstMessageAt: firstAt,
+					BestSnippet:    snippet,
+				},
+				contentScore: contentScore,
+			}
+			seen[topicID] = e
+		}
+	}
+	if err := contentRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// ── Combine & rank ───────────────────────────────────────────────────────
+	// Final score formula:
+	//   max(nameScore, contentScore)
+	//   + 0.1 * log2(1 + message_count)   [activity bonus]
+	//   + recency_bonus(last_message_at)  [0..0.5, decaying over 90 days]
+	//   + 0.15 if resolved               [resolution bonus]
+	//
+	// BM25 scores from SQLite FTS5 are negative; we negate them so higher = better.
+	// The formula is intentionally simple and tunable — no embeddings are used.
+	out := make([]TopicSearchHit, 0, len(seen))
+	for _, e := range seen {
+		base := e.nameScore
+		if e.contentScore > base {
+			base = e.contentScore
+		}
+		// Activity bonus: log2(1+count) scaled so 100 msgs ≈ +0.7
+		activity := 0.0
+		if e.MessageCount > 0 {
+			activity = math.Log2(1+float64(e.MessageCount)) * 0.1
+		}
+		// Recency decay: 0.5 when today, approaches 0 after ~90 days
+		recency := 0.0
+		if e.LastMessageAt != "" {
+			if t, err2 := time.Parse(time.RFC3339, e.LastMessageAt); err2 == nil {
+				daysAgo := time.Since(t).Hours() / 24
+				recency = 0.5 / (1 + daysAgo/30)
+			}
+		}
+		// Resolved bonus
+		resolvedBonus := 0.0
+		if e.Resolved {
+			resolvedBonus = 0.15
+		}
+		e.Rank = base + activity + recency + resolvedBonus
+		out = append(out, e.TopicSearchHit)
+	}
+
+	// Sort by descending rank.
+	sort.Slice(out, func(i, j int) bool { return out[i].Rank > out[j].Rank })
+	if len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
 }
 
 func (s *Store) Search(ctx context.Context, query, stream string, resolvedOnly bool, limit int) ([]SearchHit, error) {

--- a/internal/store/store_topic_search_test.go
+++ b/internal/store/store_topic_search_test.go
@@ -1,0 +1,256 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// seedTopicSearchDB creates a small fixture DB for topic-search tests.
+// Returns (store, ctx).
+//
+// Schema:
+//
+//	stream "general" (id=10)
+//	  topic "deployment pipeline" (resolved)     — messages about deploy/release
+//	  topic "onboarding checklist" (unresolved)  — messages about onboarding setup
+//	  topic "random banter" (unresolved)         — off-topic messages
+//	stream "dev" (id=20)
+//	  topic "bug in database layer" (unresolved) — messages about database bug
+func seedTopicSearchDB(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	st, ctx := setupTestStore(t) // reuse helper from store_test.go (same package)
+
+	// Extra stream
+	if err := st.UpsertStream(ctx, Stream{ID: 20, OrgID: 1, Name: "dev"}); err != nil {
+		t.Fatalf("UpsertStream dev: %v", err)
+	}
+	// Extra user
+	if err := st.UpsertUser(ctx, User{ID: 21, OrgID: 1, FullName: "Alice"}); err != nil {
+		t.Fatalf("UpsertUser Alice: %v", err)
+	}
+
+	topics := []struct {
+		streamID int64
+		name     string
+	}{
+		{10, "deployment pipeline"},
+		{10, "onboarding checklist"},
+		{10, "random banter"},
+		{20, "bug in database layer"},
+	}
+	topicIDs := map[string]int64{}
+	for _, tp := range topics {
+		id, err := st.GetOrCreateTopic(ctx, 1, tp.streamID, tp.name)
+		if err != nil {
+			t.Fatalf("GetOrCreateTopic %q: %v", tp.name, err)
+		}
+		topicIDs[tp.name] = id
+	}
+
+	// Mark "deployment pipeline" resolved by updating the row directly.
+	if _, err := st.db.ExecContext(ctx, `UPDATE topics SET resolved=1 WHERE id=?`, topicIDs["deployment pipeline"]); err != nil {
+		t.Fatalf("mark resolved: %v", err)
+	}
+
+	type msgFixture struct {
+		id        int64
+		streamID  int64
+		topicName string
+		senderID  int64
+		ts        string
+		content   string
+	}
+	msgs := []msgFixture{
+		// deployment pipeline — recent
+		{1001, 10, "deployment pipeline", 20, "2026-04-28T10:00:00Z", "Released v2.5 to production. Deploy went smoothly."},
+		{1002, 10, "deployment pipeline", 21, "2026-04-28T11:00:00Z", "CI pipeline passed all checks before the deploy."},
+		// onboarding checklist
+		{2001, 10, "onboarding checklist", 20, "2026-04-01T09:00:00Z", "New engineer onboarding setup steps: install Go, clone repo."},
+		{2002, 10, "onboarding checklist", 21, "2026-04-02T10:00:00Z", "Onboarding doc updated with Docker setup instructions."},
+		// random banter — old
+		{3001, 10, "random banter", 20, "2025-01-10T08:00:00Z", "Did you see the game last night?"},
+		// bug in database layer
+		{4001, 20, "bug in database layer", 20, "2026-04-25T14:00:00Z", "Found a nil pointer dereference in the database query function."},
+		{4002, 20, "bug in database layer", 21, "2026-04-26T15:00:00Z", "Fixed the database bug. Patch pushed."},
+	}
+	for _, m := range msgs {
+		if err := st.UpsertMessage(ctx, Message{
+			ID:          m.id,
+			OrgID:       1,
+			StreamID:    m.streamID,
+			TopicID:     topicIDs[m.topicName],
+			SenderID:    m.senderID,
+			Content:     m.content,
+			ContentText: m.content,
+			Timestamp:   m.ts,
+		}); err != nil {
+			t.Fatalf("UpsertMessage %d: %v", m.id, err)
+		}
+	}
+	return st, ctx
+}
+
+// TestSearchTopics_ByTopicName verifies that topics whose name matches the query
+// are returned (leg 1: topics_fts).
+func TestSearchTopics_ByTopicName(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "onboarding", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected at least one hit for 'onboarding', got none")
+	}
+	found := false
+	for _, h := range hits {
+		if h.TopicName == "onboarding checklist" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'onboarding checklist' in results; got %+v", hits)
+	}
+}
+
+// TestSearchTopics_ByMessageContent verifies that topics are found via their
+// message content even when the query term is not in the topic name (leg 2:
+// messages_fts).
+func TestSearchTopics_ByMessageContent(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	// "nil pointer" is only in message content for "bug in database layer"
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "pointer", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected hit for 'pointer' via message content, got none")
+	}
+	found := false
+	for _, h := range hits {
+		if h.TopicName == "bug in database layer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'bug in database layer' in results; got %+v", hits)
+	}
+}
+
+// TestSearchTopics_HybridBothLegs verifies that a query can match via both leg 1
+// (topic name) and leg 2 (message content) and that the result is not duplicated.
+func TestSearchTopics_HybridBothLegs(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	// "database" appears in both topic name ("bug in database layer") and message
+	// content for that same topic.
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "database", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	// Count how many times we see "bug in database layer" — should be exactly 1.
+	count := 0
+	for _, h := range hits {
+		if h.TopicName == "bug in database layer" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected topic 'bug in database layer' exactly once, got %d times; results: %+v", count, hits)
+	}
+}
+
+// TestSearchTopics_StreamFilter verifies the --stream filter is honored.
+func TestSearchTopics_StreamFilter(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	// "deploy" appears in general/deployment pipeline; filtering to dev should yield 0.
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{
+		Query:  "deploy",
+		Stream: "dev",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	for _, h := range hits {
+		if h.StreamName != "dev" {
+			t.Errorf("expected only dev stream results, got stream %q", h.StreamName)
+		}
+	}
+}
+
+// TestSearchTopics_OnlyUnresolved verifies that resolved topics are excluded
+// when OnlyUnresolved is set.
+func TestSearchTopics_OnlyUnresolved(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	// "deploy" matches "deployment pipeline" which is resolved.
+	// With OnlyUnresolved=true it should be excluded.
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{
+		Query:          "deploy",
+		OnlyUnresolved: true,
+		Limit:          10,
+	})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	for _, h := range hits {
+		if h.Resolved {
+			t.Errorf("OnlyUnresolved=true but got resolved topic %q", h.TopicName)
+		}
+	}
+}
+
+// TestSearchTopics_EmptyQuery verifies that an empty query returns an error.
+func TestSearchTopics_EmptyQuery(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+	_, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "", Limit: 10})
+	if err == nil {
+		t.Fatal("expected error for empty query, got nil")
+	}
+}
+
+// TestSearchTopics_NoResults verifies that a query matching nothing returns
+// an empty slice (not an error).
+func TestSearchTopics_NoResults(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "xyzzy_nonexistent", Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error for no-match query: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(hits))
+	}
+}
+
+// TestSearchTopics_LimitHonored verifies that the Limit option is respected.
+func TestSearchTopics_LimitHonored(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	// "a" matches pretty much everything via FTS porter stemmer.
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "deploy", Limit: 1})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	if len(hits) > 1 {
+		t.Fatalf("expected at most 1 result with Limit=1, got %d", len(hits))
+	}
+}
+
+// TestSearchTopics_SnippetPopulated verifies that BestSnippet is non-empty for
+// results that matched via message content.
+func TestSearchTopics_SnippetPopulated(t *testing.T) {
+	st, ctx := seedTopicSearchDB(t)
+
+	hits, err := st.SearchTopics(ctx, TopicSearchOptions{Query: "pipeline", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchTopics: %v", err)
+	}
+	for _, h := range hits {
+		if h.TopicName == "deployment pipeline" && h.BestSnippet == "" {
+			t.Errorf("expected BestSnippet to be populated for 'deployment pipeline'")
+		}
+	}
+}


### PR DESCRIPTION
Closes #9

## Summary

Adds `zulcrawl topics search <query>` — a two-leg hybrid topic-level search.

### What landed

**CLI:**
```
zulcrawl topics search "database migration"
zulcrawl topics search --stream engineering "deploy script"
zulcrawl topics search --unresolved --limit 10 "onboarding"
```

**Search approach (two legs, merged in Go):**
1. **Topic-name FTS** via `topics_fts` — matches topics whose title contains the query terms.
2. **Message-content FTS** via `messages_fts`, iterated per-row and grouped by topic in Go — matches topics that contain relevant messages. (bm25() is only valid in ORDER BY of a direct FTS query, not in GROUP BY/aggregate, so grouping is done in Go.)

Results are de-duplicated by topic ID and ranked by:
| Signal | Note |
|--------|------|
| BM25 relevance (best of name/content leg) | higher = better |
| Activity: log₂(1+message_count) × 0.1 | busy topics rank slightly higher |
| Recency: 0.5 / (1 + days_since_last_message/30) | decays over ~90 days |
| Resolved bonus: +0.15 | closed topics get a small lift |

Output includes a best-matching message snippet from the content leg.

### What is NOT semantic (honest accounting)

This is **local FTS/hybrid** — BM25 + handcrafted ranking signals. No vector embeddings are used. The feature is useful and ships immediately without any external dependencies.

### Deferred: embedding-provider layer

A pluggable vector-embedding provider (off by default, only called when explicitly configured) is the logical next step for true semantic search. Design notes for that work:
- Add a `[search]` config section with `embedding_provider = ""` (empty = disabled)
- Provider interface: `type EmbeddingProvider interface { Embed(ctx, texts []string) ([][]float32, error) }`
- Store embedding vectors in a new `topic_embeddings` table (float32 blob or SQLite-vec extension)
- Query: embed the user query, cosine-similarity rank against stored topic embeddings, combine with hybrid score
- Sync path: generate embeddings lazily / in background batch, never inline in the hot sync path
- First provider to implement: local Ollama (no paid API) as the safe default

## Verification

```
go test ./...          ✅ all pass
go test -race ./...    ✅ clean
govulncheck ./...      ✅ no vulnerabilities
go build ./...         ✅ clean
```

**9 new tests** in `internal/store/store_topic_search_test.go`:
- `TestSearchTopics_ByTopicName` — leg 1 (name FTS)
- `TestSearchTopics_ByMessageContent` — leg 2 (content FTS)
- `TestSearchTopics_HybridBothLegs` — deduplication when both legs match
- `TestSearchTopics_StreamFilter` — --stream filter
- `TestSearchTopics_OnlyUnresolved` — --unresolved filter
- `TestSearchTopics_EmptyQuery` — error on empty query
- `TestSearchTopics_NoResults` — no-match returns empty slice
- `TestSearchTopics_LimitHonored` — Limit respected
- `TestSearchTopics_SnippetPopulated` — BestSnippet present for content leg hits

## Files changed

| File | Change |
|------|--------|
| `internal/store/store.go` | +`TopicSearchHit`, `TopicSearchOptions`, `SearchTopics()` (+222 lines) |
| `internal/store/store_topic_search_test.go` | 9 new tests (+256 lines) |
| `internal/cli/root.go` | `topicsCmd` extended with `search` subcommand (+69 lines) |
| `README.md` | `topics search` docs, scoring table, deferred embedding design (+48 lines) |