### PR TITLE
feat: add optional Ollama embeddings for semantic topic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   - `sql`
   - `messages` — direct archive slice queries (see below)
   - `backfill-indexes` — rebuild mention/attachment indexes for existing messages
+  - `embeddings backfill` — build/update Ollama topic embeddings (disabled by default)
+  - `embeddings status` — show embedding coverage
+  - `topics search --semantic` — vector/semantic topic search when embeddings enabled
 - Syncer with parallel stream workers and incremental sync (`sync_state`)
 - HTML-to-text conversion for indexing
 - Search ranking with FTS BM25, resolved-topic boost, and recency boost
@@ -197,8 +200,79 @@ Output format per message:
 
 ```
 
-## Notes
-
 - Uses `modernc.org/sqlite` (pure Go, no CGO)
 - Current implementation focuses on core mirror/search flow
-- Planned later (per spec): tail/event queue, MCP server, vector-embedding semantic search (pluggable provider, off by default), summarization, Q&A extraction
+- Planned later (per spec): tail/event queue, MCP server, summarization, Q&A extraction
+
+## Semantic Search (optional, Ollama embeddings)
+
+Embeddings are **disabled by default**. No embedding calls are ever made unless you explicitly enable them.
+
+### Quick-start
+
+```bash
+# 1. Add to ~/.zulcrawl/config.toml
+cat >> ~/.zulcrawl/config.toml <<'EOF'
+[embeddings]
+enabled   = true
+model     = "nomic-embed-text-v2-moe"   # recommended; ~550 MB
+# provider   = "ollama"                 # only supported provider
+# ollama_base = "http://localhost:11434" # default
+# batch_size  = 32                      # texts per /api/embed request
+# sample_messages = 50                  # messages sampled per topic
+EOF
+
+# 2. Start Ollama and pull the model
+ollama serve &
+ollama pull nomic-embed-text-v2-moe
+
+# 3. Build embeddings for all topics
+zulcrawl embeddings backfill
+
+# 4. Semantic topic search
+zulcrawl topics search --semantic "database migration strategy"
+```
+
+### Notes and limitations
+
+- **First-run latency**: embedding a large archive (thousands of topics) may take
+  several minutes on first run. Subsequent incremental runs only embed new topics.
+- **No cloud calls**: all embeddings are generated locally via Ollama.
+- **No Python**: pure Go implementation using Ollama's HTTP API.
+- **No sqlite-vec / HNSW**: brute-force cosine similarity is used. This is fast
+  enough for typical Zulip archive sizes.
+- **Heavier alternative**: `bge-m3` can be used instead of `nomic-embed-text-v2-moe`
+  for potentially better recall on multilingual corpora; pull and update config.
+- **Model change**: if you switch models, re-embed everything with:
+  `zulcrawl embeddings backfill --force`
+- **Dimension mismatch**: mixing vectors from different models produces wrong
+  results. zulcrawl detects this and emits a clear error asking you to re-embed.
+
+### Commands
+
+```bash
+# Build/update embeddings
+zulcrawl embeddings backfill
+zulcrawl embeddings backfill --batch 16   # smaller batches for low RAM
+zulcrawl embeddings backfill --limit 500  # embed at most N topics
+zulcrawl embeddings backfill --force      # re-embed everything (model change)
+
+# Check embedding coverage
+zulcrawl embeddings status
+
+# Semantic topic search
+zulcrawl topics search --semantic "deploy pipeline"
+zulcrawl topics search --semantic --stream engineering "API rate limit"
+```
+
+### `topics search` flags (updated)
+
+| Flag | Description |
+|------|-------------|
+| `--stream NAME` | Filter by stream name |
+| `--unresolved` | Exclude resolved topics |
+| `--limit N` | Maximum topics to return (default 20) |
+| `--semantic` | Use Ollama vector search (requires embeddings enabled + backfilled) |
+
+FTS-only behaviour is **unchanged** when `--semantic` is not set.
+

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -351,9 +351,10 @@ FTS-only behaviour is the default and remains unchanged.`,
 					return err
 				}
 				hits, err := embeddings.SemanticSearch(ctx, st, client, embeddings.SemanticSearchOptions{
-					Query:  args[0],
-					Stream: stream,
-					Limit:  limit,
+					Query:          args[0],
+					Stream:         stream,
+					Limit:          limit,
+					OnlyUnresolved: unresolved,
 				})
 				if err != nil {
 					return err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/embed"
+	"github.com/FtlC-ian/zulcrawl/internal/embeddings"
 	"github.com/FtlC-ian/zulcrawl/internal/lock"
 	"github.com/FtlC-ian/zulcrawl/internal/search"
 	"github.com/FtlC-ian/zulcrawl/internal/store"
@@ -40,6 +42,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(sqlCmd(loadCfg))
 	root.AddCommand(messagesCmd(loadCfg))
 	root.AddCommand(backfillIndexesCmd(loadCfg))
+	root.AddCommand(embeddingsCmd(loadCfg))
 	return root
 }
 
@@ -294,6 +297,7 @@ func topicsSearchCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	var stream string
 	var unresolved bool
 	var limit int
+	var semantic bool
 	cmd := &cobra.Command{
 		Use:   "search [query]",
 		Short: "Hybrid topic-level search (FTS on topic names + message content)",
@@ -306,7 +310,14 @@ Results are ranked by:
   - Resolved bonus: resolved topics get a small lift
 
 This is a purely local FTS/hybrid search. No remote embedding APIs are called.
-Embedding-provider integration is left for a future chunk (see issue #9).`,
+
+When --semantic is set, semantic/vector scoring participates alongside FTS.
+This requires embeddings to be enabled and backfilled:
+  1. Set [embeddings] enabled = true in config
+  2. ollama pull nomic-embed-text-v2-moe
+  3. zulcrawl embeddings backfill
+
+FTS-only behaviour is the default and remains unchanged.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadCfg()
@@ -318,6 +329,55 @@ Embedding-provider integration is left for a future chunk (see issue #9).`,
 				return err
 			}
 			defer st.Close()
+
+			// --- Semantic mode ---------------------------------------------------
+			if semantic {
+				if !cfg.Embeddings.Enabled {
+					return fmt.Errorf(
+						"semantic search requires embeddings to be enabled.\n" +
+							"Set [embeddings] enabled = true in config, then run:\n" +
+							"  ollama pull %s\n" +
+							"  zulcrawl embeddings backfill",
+						cfg.Embeddings.Model)
+				}
+				client := embed.NewOllamaClient(
+					cfg.Embeddings.OllamaBase,
+					cfg.Embeddings.Model,
+					cfg.Embeddings.BatchSize,
+				)
+				ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+				defer cancel()
+				if err := client.CheckAvailable(ctx); err != nil {
+					return err
+				}
+				hits, err := embeddings.SemanticSearch(ctx, st, client, embeddings.SemanticSearchOptions{
+					Query:  args[0],
+					Stream: stream,
+					Limit:  limit,
+				})
+				if err != nil {
+					return err
+				}
+				if len(hits) == 0 {
+					fmt.Fprintln(cmd.OutOrStdout(), "No topics found.")
+					return nil
+				}
+				for _, h := range hits {
+					res := ""
+					if h.Resolved {
+						res = " [resolved]"
+					}
+					lastAt := h.LastMessageAt
+					if t, err2 := time.Parse(time.RFC3339, h.LastMessageAt); err2 == nil {
+						lastAt = t.Format("2006-01-02")
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "#%s > %s%s (%d msgs, last %s, score %.3f)\n",
+						h.StreamName, h.TopicName, res, h.MessageCount, lastAt, h.Score)
+				}
+				return nil
+			}
+
+			// --- FTS mode (default) ---------------------------------------------
 			hits, err := st.SearchTopics(cmd.Context(), store.TopicSearchOptions{
 				Query:          args[0],
 				Stream:         stream,
@@ -353,6 +413,7 @@ Embedding-provider integration is left for a future chunk (see issue #9).`,
 	cmd.Flags().StringVar(&stream, "stream", "", "filter by stream name")
 	cmd.Flags().BoolVar(&unresolved, "unresolved", false, "only unresolved topics")
 	cmd.Flags().IntVar(&limit, "limit", 20, "max topics to return")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "use semantic/vector search (requires embeddings enabled + backfilled)")
 	return cmd
 }
 
@@ -646,4 +707,171 @@ func flatString(m map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// embeddingsCmd is the parent command for embedding management.
+func embeddingsCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "embeddings",
+		Short: "Manage topic embeddings (Ollama, disabled by default)",
+		Long: `Manage local topic embeddings for semantic/vector search.
+
+Embeddings are DISABLED by default. No calls are made to Ollama or any remote
+service unless you explicitly enable them in config.
+
+To enable:
+  1. Edit ~/.zulcrawl/config.toml and add:
+       [embeddings]
+       enabled = true
+       model   = "nomic-embed-text-v2-moe"
+  2. Start Ollama:   ollama serve
+  3. Pull the model: ollama pull nomic-embed-text-v2-moe
+  4. Run backfill:   zulcrawl embeddings backfill
+  5. Search:         zulcrawl topics search --semantic "your query"
+
+First-run latency depends on the model and corpus size. Subsequent incremental
+backfills only embed newly-added topics.`,
+	}
+	cmd.AddCommand(embeddingsBackfillCmd(loadCfg))
+	cmd.AddCommand(embeddingsStatusCmd(loadCfg))
+	return cmd
+}
+
+func embeddingsBackfillCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var batchSize int
+	var limit int
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Build or update topic embeddings",
+		Long: `Embed all topics that do not yet have a stored vector for the configured model.
+
+Requires:
+  - [embeddings] enabled = true in config
+  - Ollama running: ollama serve
+  - Model pulled:   ollama pull <model>
+
+Backfill is incremental: only topics without an existing embedding are processed.
+Use --force to re-embed all topics (e.g. after changing the model).
+
+Note: on first run with a large archive the process may take several minutes.
+Progress is printed as batches complete.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			if !cfg.Embeddings.Enabled {
+				return fmt.Errorf(
+					"embeddings are disabled.\n" +
+						"Set [embeddings] enabled = true in config, then:\n" +
+						"  ollama pull %s",
+					cfg.Embeddings.Model)
+			}
+
+			lockPath := cfg.DBPath() + ".lock"
+			l, err := lock.Acquire(lockPath)
+			if err != nil {
+				return err
+			}
+			defer l.Release()
+
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			ctx := cmd.Context()
+			if err := st.InitSchema(ctx); err != nil {
+				return err
+			}
+
+			if batchSize > 0 {
+				cfg.Embeddings.BatchSize = batchSize
+			}
+
+			client := embed.NewOllamaClient(
+				cfg.Embeddings.OllamaBase,
+				cfg.Embeddings.Model,
+				cfg.Embeddings.BatchSize,
+			)
+
+			// Verify Ollama is reachable and model is present before doing any work.
+			checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+			if err := client.CheckAvailable(checkCtx); err != nil {
+				return err
+			}
+
+			if force {
+				// Drop all stored embeddings for this model so backfill re-embeds everything.
+				fmt.Fprintf(os.Stderr, "--force: clearing existing embeddings for model %q\n", cfg.Embeddings.Model)
+				if err := st.DeleteEmbeddingsByModel(ctx, cfg.Embeddings.Model); err != nil {
+					return fmt.Errorf("clear embeddings: %w", err)
+				}
+			}
+
+			_, err = embeddings.Backfill(ctx, cfg, st, client, embeddings.BackfillOptions{
+				BatchSize: batchSize,
+				Limit:     limit,
+			}, os.Stdout)
+			return err
+		},
+	}
+	cmd.Flags().IntVar(&batchSize, "batch", 0, "override batch size from config")
+	cmd.Flags().IntVar(&limit, "limit", 0, "only embed this many topics (0 = all)")
+	cmd.Flags().BoolVar(&force, "force", false, "re-embed all topics, even if already embedded")
+	return cmd
+}
+
+func embeddingsStatusCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show embedding coverage for the configured model",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			if !cfg.Embeddings.Enabled {
+				fmt.Println("embeddings: disabled (set [embeddings] enabled = true to activate)")
+				return nil
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			ctx := cmd.Context()
+
+			info, err := st.EmbeddingStats(ctx, cfg.Embeddings.Model)
+			if err != nil {
+				return err
+			}
+			stats, err := st.Stats(ctx)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("embeddings status\n")
+			fmt.Printf("  enabled:  %v\n", cfg.Embeddings.Enabled)
+			fmt.Printf("  model:    %s\n", cfg.Embeddings.Model)
+			fmt.Printf("  provider: %s\n", cfg.Embeddings.Provider)
+			fmt.Printf("  base:     %s\n", cfg.Embeddings.OllamaBase)
+			fmt.Printf("  topics total: %d\n", stats.Topics)
+			if info != nil {
+				fmt.Printf("  embedded:     %d\n", info.Count)
+				fmt.Printf("  dimension:    %d\n", info.Dim)
+				missing := stats.Topics - info.Count
+				fmt.Printf("  missing:      %d\n", missing)
+				if missing > 0 {
+					fmt.Println("  hint: run `zulcrawl embeddings backfill` to embed missing topics")
+				}
+			} else {
+				fmt.Println("  embedded:     0 (no embeddings yet)")
+				fmt.Println("  hint: run `zulcrawl embeddings backfill` to get started")
+			}
+			return nil
+		},
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -334,11 +334,14 @@ FTS-only behaviour is the default and remains unchanged.`,
 			if semantic {
 				if !cfg.Embeddings.Enabled {
 					return fmt.Errorf(
-						"semantic search requires embeddings to be enabled.\n" +
-							"Set [embeddings] enabled = true in config, then run:\n" +
-							"  ollama pull %s\n" +
+						"semantic search requires embeddings to be enabled.\n"+
+							"Set [embeddings] enabled = true in config, then run:\n"+
+							"  ollama pull %s\n"+
 							"  zulcrawl embeddings backfill",
 						cfg.Embeddings.Model)
+				}
+				if err := cfg.ValidateEmbeddings(); err != nil {
+					return err
 				}
 				client := embed.NewOllamaClient(
 					cfg.Embeddings.OllamaBase,
@@ -764,10 +767,13 @@ Progress is printed as batches complete.`,
 			}
 			if !cfg.Embeddings.Enabled {
 				return fmt.Errorf(
-					"embeddings are disabled.\n" +
-						"Set [embeddings] enabled = true in config, then:\n" +
+					"embeddings are disabled.\n"+
+						"Set [embeddings] enabled = true in config, then:\n"+
 						"  ollama pull %s",
 					cfg.Embeddings.Model)
+			}
+			if err := cfg.ValidateEmbeddings(); err != nil {
+				return err
 			}
 
 			lockPath := cfg.DBPath() + ".lock"
@@ -837,6 +843,9 @@ func embeddingsStatusCmd(loadCfg func() (*config.Config, error)) *cobra.Command 
 			if !cfg.Embeddings.Enabled {
 				fmt.Println("embeddings: disabled (set [embeddings] enabled = true to activate)")
 				return nil
+			}
+			if err := cfg.ValidateEmbeddings(); err != nil {
+				return err
 			}
 			st, err := store.Open(cfg.DBPath())
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,24 @@ type Config struct {
 		SemanticEnabled bool   `toml:"semantic_enabled"`
 		EmbeddingModel  string `toml:"embedding_model"`
 	} `toml:"search"`
+	Embeddings struct {
+		// Enabled controls whether embedding features are compiled-in and available.
+		// Default: false. No embedding calls are made unless this is true.
+		Enabled bool `toml:"enabled"`
+		// Provider selects the embedding backend. Only "ollama" is supported.
+		Provider string `toml:"provider"`
+		// OllamaBase is the Ollama server base URL. Defaults to http://localhost:11434.
+		OllamaBase string `toml:"ollama_base"`
+		// Model is the embedding model name, e.g. "nomic-embed-text-v2-moe".
+		// Pull it first: ollama pull nomic-embed-text-v2-moe
+		Model string `toml:"model"`
+		// BatchSize is the number of texts per Ollama /api/embed request.
+		// Defaults to 32.
+		BatchSize int `toml:"batch_size"`
+		// SampleMessages is the number of messages sampled per topic when
+		// building its embedding text. Defaults to 50.
+		SampleMessages int `toml:"sample_messages"`
+	} `toml:"embeddings"`
 	MCP struct {
 		Enabled bool `toml:"enabled"`
 		Port    int  `toml:"port"`
@@ -45,6 +63,12 @@ func Default() *Config {
 	c.Sync.ExcludeStreams = []string{"social", "random"}
 	c.Tail.RepairInterval = "30m"
 	c.MCP.Port = 8849
+	c.Embeddings.Enabled = false
+	c.Embeddings.Provider = "ollama"
+	c.Embeddings.OllamaBase = "http://localhost:11434"
+	c.Embeddings.Model = "nomic-embed-text-v2-moe"
+	c.Embeddings.BatchSize = 32
+	c.Embeddings.SampleMessages = 50
 	return c
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,21 @@ func (c *Config) DBPath() string {
 	return ExpandPath(c.Database.Path)
 }
 
+func (c *Config) ValidateEmbeddings() error {
+	if !c.Embeddings.Enabled {
+		return nil
+	}
+	provider := strings.ToLower(strings.TrimSpace(c.Embeddings.Provider))
+	if provider == "" {
+		provider = "ollama"
+		c.Embeddings.Provider = provider
+	}
+	if provider != "ollama" {
+		return fmt.Errorf("embeddings.provider %q is not supported (only \"ollama\" is supported)", c.Embeddings.Provider)
+	}
+	return nil
+}
+
 func (c *Config) ValidateAuth() error {
 	if c.Zulip.URL == "" {
 		return errors.New("zulip.url is missing (config or ZULIP_URL)")

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -1,0 +1,258 @@
+// Package embed provides a thin client for generating text embeddings via
+// a local Ollama server (http://localhost:11434 by default).
+//
+// Only brute-force cosine similarity is used; no vector extension is required.
+// The client normalises every returned vector to unit length so that cosine
+// similarity reduces to a dot product at query time.
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultOllamaBase is the default Ollama server URL.
+const DefaultOllamaBase = "http://localhost:11434"
+
+// DefaultBatchSize is the number of texts sent in a single /api/embed request.
+const DefaultBatchSize = 32
+
+// Client generates embeddings from a text input.
+type Client interface {
+	// Embed returns a normalised float32 vector for each input text.
+	// The returned slice is parallel to texts; len(result) == len(texts).
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+
+	// Model returns the model identifier used by this client.
+	Model() string
+
+	// Dim returns the expected embedding dimension, or 0 if unknown.
+	Dim() int
+}
+
+// OllamaClient calls the Ollama /api/embed endpoint.
+// It implements Client.
+type OllamaClient struct {
+	base      string
+	model     string
+	batchSize int
+	dim       int // 0 = not yet observed
+	http      *http.Client
+}
+
+// NewOllamaClient constructs an OllamaClient.
+// base defaults to DefaultOllamaBase; batchSize defaults to DefaultBatchSize.
+func NewOllamaClient(base, model string, batchSize int) *OllamaClient {
+	if base == "" {
+		base = DefaultOllamaBase
+	}
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+	return &OllamaClient{
+		base:      strings.TrimRight(base, "/"),
+		model:     model,
+		batchSize: batchSize,
+		http: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}
+}
+
+func (c *OllamaClient) Model() string { return c.model }
+func (c *OllamaClient) Dim() int      { return c.dim }
+
+// ollamaEmbedRequest mirrors the /api/embed request body.
+type ollamaEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// ollamaEmbedResponse mirrors the /api/embed response body.
+type ollamaEmbedResponse struct {
+	Model      string      `json:"model"`
+	Embeddings [][]float64 `json:"embeddings"`
+}
+
+// tag is a single model entry from /api/tags.
+type tag struct {
+	Name string `json:"name"`
+}
+
+// Embed sends texts in batches and returns normalised float32 vectors.
+func (c *OllamaClient) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += c.batchSize {
+		end := start + c.batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		batch := texts[start:end]
+		vecs, err := c.embedBatch(ctx, batch)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (c *OllamaClient) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	body, err := json.Marshal(ollamaEmbedRequest{
+		Model: c.model,
+		Input: texts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("embed: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embed: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embed: ollama request failed — is Ollama running at %s? (%w)", c.base, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var body strings.Builder
+		_, _ = io.Copy(&body, resp.Body)
+		return nil, fmt.Errorf("embed: ollama returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(body.String()))
+	}
+
+	var result ollamaEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("embed: decode response: %w", err)
+	}
+	if len(result.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("embed: expected %d vectors, got %d", len(texts), len(result.Embeddings))
+	}
+
+	vecs := make([][]float32, len(result.Embeddings))
+	for i, raw := range result.Embeddings {
+		vecs[i] = normalizeF32(raw)
+		if c.dim == 0 && len(vecs[i]) > 0 {
+			c.dim = len(vecs[i])
+		}
+	}
+	return vecs, nil
+}
+
+// CheckAvailable pings Ollama and verifies the requested model is present.
+// Returns a helpful error message if not.
+func (c *OllamaClient) CheckAvailable(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/api/tags", nil)
+	if err != nil {
+		return fmt.Errorf("embed: cannot build request to %s: %w", c.base, err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("embed: Ollama not reachable at %s — run `ollama serve` first: %w", c.base, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("embed: Ollama /api/tags returned HTTP %d", resp.StatusCode)
+	}
+	type listResp struct {
+		Models []tag `json:"models"`
+	}
+	var lr listResp
+	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+		return fmt.Errorf("embed: decode /api/tags: %w", err)
+	}
+	for _, m := range lr.Models {
+		// Ollama model names may include a ":latest" suffix.
+		if strings.EqualFold(m.Name, c.model) || strings.EqualFold(strings.SplitN(m.Name, ":", 2)[0], strings.SplitN(c.model, ":", 2)[0]) {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"embed: model %q not found in Ollama — pull it first:\n  ollama pull %s\nAvailable models: %s",
+		c.model, c.model, formatModelList(lr.Models),
+	)
+}
+
+func formatModelList(tags []tag) string {
+	names := make([]string, len(tags))
+	for i, t := range tags {
+		names[i] = t.Name
+	}
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}
+
+// normalizeF32 converts a float64 slice to float32 and normalises to unit length.
+// If the vector is all-zero it is returned as-is.
+func normalizeF32(v []float64) []float32 {
+	out := make([]float32, len(v))
+	var sum float64
+	for _, x := range v {
+		sum += x * x
+	}
+	norm := math.Sqrt(sum)
+	if norm < 1e-10 {
+		for i, x := range v {
+			out[i] = float32(x)
+		}
+		return out
+	}
+	for i, x := range v {
+		out[i] = float32(x / norm)
+	}
+	return out
+}
+
+// CosineSimilarity computes the dot product of two unit-length float32 vectors.
+// Both vectors must have the same length; behaviour is undefined otherwise.
+func CosineSimilarity(a, b []float32) float64 {
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return dot
+}
+
+// EncodeVec serialises a float32 vector to little-endian bytes for SQLite BLOB storage.
+func EncodeVec(v []float32) []byte {
+	b := make([]byte, len(v)*4)
+	for i, x := range v {
+		bits := math.Float32bits(x)
+		b[i*4] = byte(bits)
+		b[i*4+1] = byte(bits >> 8)
+		b[i*4+2] = byte(bits >> 16)
+		b[i*4+3] = byte(bits >> 24)
+	}
+	return b
+}
+
+// DecodeVec deserialises a float32 vector from little-endian bytes.
+func DecodeVec(b []byte) ([]float32, error) {
+	if len(b)%4 != 0 {
+		return nil, fmt.Errorf("embed: vector byte length %d is not a multiple of 4", len(b))
+	}
+	v := make([]float32, len(b)/4)
+	for i := range v {
+		bits := uint32(b[i*4]) |
+			uint32(b[i*4+1])<<8 |
+			uint32(b[i*4+2])<<16 |
+			uint32(b[i*4+3])<<24
+		v[i] = math.Float32frombits(bits)
+	}
+	return v, nil
+}

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -1,0 +1,97 @@
+package embed
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFakeClientReturnsUnitVectors(t *testing.T) {
+	c := NewFakeClient("test-model", 8)
+	vecs, err := c.Embed(context.Background(), []string{"hello", "world", "foo"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("expected 3 vectors, got %d", len(vecs))
+	}
+	for i, v := range vecs {
+		if len(v) != 8 {
+			t.Errorf("vec[%d]: expected dim=8, got %d", i, len(v))
+		}
+		if !IsUnitLength(v) {
+			t.Errorf("vec[%d]: not unit length", i)
+		}
+	}
+}
+
+func TestFakeClientDeterministic(t *testing.T) {
+	c := NewFakeClient("test-model", 4)
+	v1, _ := c.Embed(context.Background(), []string{"hello"})
+	v2, _ := c.Embed(context.Background(), []string{"hello"})
+	for i := range v1[0] {
+		if v1[0][i] != v2[0][i] {
+			t.Errorf("non-deterministic at index %d: %v vs %v", i, v1[0][i], v2[0][i])
+		}
+	}
+}
+
+func TestFakeClientDifferentTexts(t *testing.T) {
+	c := NewFakeClient("test-model", 4)
+	vecs, _ := c.Embed(context.Background(), []string{"hello", "world"})
+	identical := true
+	for i := range vecs[0] {
+		if vecs[0][i] != vecs[1][i] {
+			identical = false
+			break
+		}
+	}
+	if identical {
+		t.Error("expected different vectors for different texts")
+	}
+}
+
+func TestEncodeDecodeRoundtrip(t *testing.T) {
+	c := NewFakeClient("test-model", 16)
+	vecs, _ := c.Embed(context.Background(), []string{"round trip test"})
+	v := vecs[0]
+	got, err := EncodeDecodeRoundtrip(v)
+	if err != nil {
+		t.Fatalf("EncodeDecodeRoundtrip: %v", err)
+	}
+	if len(got) != len(v) {
+		t.Fatalf("length mismatch: want %d got %d", len(v), len(got))
+	}
+	for i := range v {
+		if v[i] != got[i] {
+			t.Errorf("index %d: want %v got %v", i, v[i], got[i])
+		}
+	}
+}
+
+func TestEncodeDecodeInvalidLength(t *testing.T) {
+	_, err := DecodeVec([]byte{1, 2, 3}) // not divisible by 4
+	if err == nil {
+		t.Fatal("expected error for invalid byte length")
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	// Two identical unit vectors → similarity ≈ 1.0
+	c := NewFakeClient("test-model", 4)
+	vecs, _ := c.Embed(context.Background(), []string{"same"})
+	sim := CosineSimilarity(vecs[0], vecs[0])
+	if sim < 0.9999 {
+		t.Errorf("expected similarity ~1.0 for identical vectors, got %f", sim)
+	}
+}
+
+func TestEmptyEmbed(t *testing.T) {
+	c := NewFakeClient("test-model", 4)
+	vecs, err := c.Embed(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Embed nil: %v", err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("expected empty result, got %d vectors", len(vecs))
+	}
+}

--- a/internal/embed/fake.go
+++ b/internal/embed/fake.go
@@ -1,0 +1,85 @@
+package embed
+
+import (
+	"context"
+	"math"
+)
+
+// FakeClient is a Client implementation for use in tests.
+// It returns deterministic unit-length vectors without any network call.
+type FakeClient struct {
+	model string
+	dim   int
+	// EmbedFunc can be set to override the default deterministic behaviour.
+	EmbedFunc func(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+// NewFakeClient creates a FakeClient that returns dim-dimensional unit vectors.
+// dim defaults to 4 when ≤ 0.
+func NewFakeClient(model string, dim int) *FakeClient {
+	if dim <= 0 {
+		dim = 4
+	}
+	return &FakeClient{model: model, dim: dim}
+}
+
+func (f *FakeClient) Model() string { return f.model }
+func (f *FakeClient) Dim() int      { return f.dim }
+
+// Embed returns a synthetic unit-length vector for each input text.
+// The first component equals cos(hash(text)) and the rest are spread evenly on
+// the unit hypersphere; uniqueness is good enough for test assertions.
+func (f *FakeClient) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if f.EmbedFunc != nil {
+		return f.EmbedFunc(ctx, texts)
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = fakeVec(t, f.dim)
+	}
+	return out, nil
+}
+
+// fakeVec returns a stable unit-length float32 vector derived from text.
+func fakeVec(text string, dim int) []float32 {
+	// Use a simple hash seed derived from the text so identical texts produce
+	// identical vectors.
+	seed := uint32(2166136261)
+	for _, b := range []byte(text) {
+		seed ^= uint32(b)
+		seed *= 16777619
+	}
+
+	v := make([]float64, dim)
+	for i := range v {
+		seed ^= seed << 13
+		seed ^= seed >> 17
+		seed ^= seed << 5
+		v[i] = float64(int32(seed)) / float64(1<<31)
+	}
+	return normalizeF32(v)
+}
+
+// CosineSimilarityTest is a convenience function for test assertions.
+func CosineSimilarityTest(a, b []float32) float64 {
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return dot
+}
+
+// EncodeDecodeRoundtrip checks that encode→decode is lossless within float32
+// precision. Exported for use in tests.
+func EncodeDecodeRoundtrip(v []float32) ([]float32, error) {
+	return DecodeVec(EncodeVec(v))
+}
+
+// IsUnitLength reports whether v is within tolerance of unit length.
+func IsUnitLength(v []float32) bool {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	return math.Abs(sum-1.0) < 1e-5
+}

--- a/internal/embeddings/backfill.go
+++ b/internal/embeddings/backfill.go
@@ -1,0 +1,247 @@
+// Package embeddings provides topic embedding backfill and semantic search.
+//
+// Embeddings are disabled by default.  They require:
+//   - [embeddings] enabled = true in config
+//   - An Ollama server running locally
+//   - The configured model pulled: ollama pull nomic-embed-text-v2-moe
+//
+// No paid or cloud APIs are called.  No Python is required.  No sqlite-vec
+// or HNSW index is used — brute-force cosine similarity is sufficient for
+// the expected corpus size.
+package embeddings
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/embed"
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+// BackfillOptions controls how the backfill command runs.
+type BackfillOptions struct {
+	// BatchSize is the number of topics sent to the embedding client at once.
+	// Defaults to cfg.Embeddings.BatchSize.
+	BatchSize int
+	// Limit caps the total number of topics to embed. 0 = all.
+	Limit int
+}
+
+// BackfillResult summarises what happened.
+type BackfillResult struct {
+	Embedded  int
+	Skipped   int
+	AlreadyOK int
+}
+
+// Backfill builds embeddings for all topics that do not yet have one for the
+// configured model.  It logs progress to w.
+func Backfill(ctx context.Context, cfg *config.Config, st *store.Store, client embed.Client, opts BackfillOptions, w io.Writer) (*BackfillResult, error) {
+	if !cfg.Embeddings.Enabled {
+		return nil, fmt.Errorf("embeddings: feature is disabled — set [embeddings] enabled = true in config")
+	}
+
+	model := client.Model()
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = cfg.Embeddings.BatchSize
+	}
+	if batchSize <= 0 {
+		batchSize = 32
+	}
+
+	// Detect model/dimension mismatch with existing stored embeddings.
+	if err := checkModelMismatch(ctx, st, model, client.Dim()); err != nil {
+		return nil, err
+	}
+
+	// Get all topic IDs that still need embedding.
+	topicIDs, err := st.TopicsNeedingEmbedding(ctx, model, opts.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: list topics: %w", err)
+	}
+
+	result := &BackfillResult{}
+	total := len(topicIDs)
+	if total == 0 {
+		fmt.Fprintln(w, "embeddings: all topics are already embedded.")
+		return result, nil
+	}
+	fmt.Fprintf(w, "embeddings: %d topics to embed with model %q\n", total, model)
+
+	done := 0
+	for start := 0; start < len(topicIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(topicIDs) {
+			end = len(topicIDs)
+		}
+		batch := topicIDs[start:end]
+
+		texts := make([]string, 0, len(batch))
+		validIDs := make([]int64, 0, len(batch))
+		for _, id := range batch {
+			text, err := st.TopicText(ctx, id, cfg.Embeddings.SampleMessages)
+			if err != nil {
+				fmt.Fprintf(w, "  skip topic %d: %v\n", id, err)
+				result.Skipped++
+				continue
+			}
+			texts = append(texts, text)
+			validIDs = append(validIDs, id)
+		}
+		if len(texts) == 0 {
+			continue
+		}
+
+		vecs, err := client.Embed(ctx, texts)
+		if err != nil {
+			return result, fmt.Errorf("embeddings: embed batch starting at topic %d: %w", batch[0], err)
+		}
+		if len(vecs) != len(validIDs) {
+			return result, fmt.Errorf("embeddings: expected %d vectors, got %d", len(validIDs), len(vecs))
+		}
+
+		for i, id := range validIDs {
+			if err := st.UpsertTopicEmbedding(ctx, id, model, cfg.Embeddings.Provider, vecs[i]); err != nil {
+				return result, fmt.Errorf("embeddings: store topic %d: %w", id, err)
+			}
+			result.Embedded++
+		}
+
+		done += len(batch)
+		pct := 100 * done / total
+		fmt.Fprintf(w, "  %d/%d (%d%%) embedded\n", done, total, pct)
+	}
+
+	fmt.Fprintf(w, "embeddings: done. embedded=%d skipped=%d\n", result.Embedded, result.Skipped)
+	return result, nil
+}
+
+// SemanticHit is a single topic result from semantic search.
+type SemanticHit struct {
+	TopicID       int64
+	StreamName    string
+	TopicName     string
+	Resolved      bool
+	MessageCount  int
+	LastMessageAt string
+	Score         float64
+}
+
+// SemanticSearchOptions controls semantic search.
+type SemanticSearchOptions struct {
+	Query  string
+	Stream string
+	Limit  int
+}
+
+// SemanticSearch performs a brute-force cosine similarity search over stored
+// topic embeddings.  It returns an error if no embeddings exist for the model.
+func SemanticSearch(ctx context.Context, st *store.Store, client embed.Client, opts SemanticSearchOptions) ([]SemanticHit, error) {
+	model := client.Model()
+	info, err := st.EmbeddingStats(ctx, model)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: check stats: %w", err)
+	}
+	if info == nil || info.Count == 0 {
+		return nil, fmt.Errorf(
+			"embeddings: no embeddings found for model %q — run `zulcrawl embeddings backfill` first",
+			model,
+		)
+	}
+
+	// Embed the query.
+	qvecs, err := client.Embed(ctx, []string{opts.Query})
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: embed query: %w", err)
+	}
+	qvec := qvecs[0]
+
+	// Load all vectors.
+	ids, vecs, err := st.AllEmbeddings(ctx, model)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: load embeddings: %w", err)
+	}
+
+	// Validate dimension consistency.
+	if len(vecs) > 0 && len(vecs[0]) != len(qvec) {
+		return nil, fmt.Errorf(
+			"embeddings: dimension mismatch — stored vectors have dim=%d but query produced dim=%d.\n"+
+				"This usually means the model changed. Re-embed with:\n  zulcrawl embeddings backfill --force",
+			len(vecs[0]), len(qvec),
+		)
+	}
+
+	type scored struct {
+		id    int64
+		score float64
+	}
+	scores := make([]scored, len(ids))
+	for i, v := range vecs {
+		scores[i] = scored{id: ids[i], score: embed.CosineSimilarity(qvec, v)}
+	}
+	sort.Slice(scores, func(i, j int) bool { return scores[i].score > scores[j].score })
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if len(scores) > limit {
+		scores = scores[:limit]
+	}
+
+	// Fetch topic metadata for results.
+	out := make([]SemanticHit, 0, len(scores))
+	for _, s := range scores {
+		meta, err := st.TopicMeta(ctx, s.id)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("embeddings: get topic meta %d: %w", s.id, err)
+		}
+		if opts.Stream != "" && meta.StreamName != opts.Stream {
+			continue
+		}
+		out = append(out, SemanticHit{
+			TopicID:       s.id,
+			StreamName:    meta.StreamName,
+			TopicName:     meta.TopicName,
+			Resolved:      meta.Resolved,
+			MessageCount:  meta.MessageCount,
+			LastMessageAt: meta.LastMessageAt,
+			Score:         s.score,
+		})
+	}
+	return out, nil
+}
+
+// checkModelMismatch returns an error if there are already embeddings stored
+// under a *different* dimension for the same model (can't happen) or if the
+// stored dimension doesn't match what the client will produce (dim=0 means
+// unknown, skip check).
+func checkModelMismatch(ctx context.Context, st *store.Store, model string, clientDim int) error {
+	if clientDim <= 0 {
+		return nil // dimension not yet known, skip
+	}
+	info, err := st.EmbeddingStats(ctx, model)
+	if err != nil {
+		return fmt.Errorf("embeddings: check stored dimension: %w", err)
+	}
+	if info == nil {
+		return nil // no stored embeddings yet
+	}
+	if info.Dim != clientDim {
+		return fmt.Errorf(
+			"embeddings: dimension mismatch for model %q — stored=%d, client=%d.\n"+
+				"This usually means you changed the model. Re-embed all topics with:\n"+
+				"  zulcrawl embeddings backfill --force",
+			model, info.Dim, clientDim,
+		)
+	}
+	return nil
+}

--- a/internal/embeddings/backfill.go
+++ b/internal/embeddings/backfill.go
@@ -12,7 +12,6 @@ package embeddings
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"sort"
@@ -105,6 +104,19 @@ func Backfill(ctx context.Context, cfg *config.Config, st *store.Store, client e
 			return result, fmt.Errorf("embeddings: expected %d vectors, got %d", len(validIDs), len(vecs))
 		}
 
+		// P1 fix: validate dimension against stored embeddings after the first
+		// real embed response.  client.Dim() returns 0 until the first Embed call
+		// (OllamaClient lazily sets it), so the pre-flight checkModelMismatch at
+		// the top of Backfill is a no-op on a fresh client.  We catch the mismatch
+		// here — before any writes — using the actual vector length returned by
+		// the model, so mixed-dimension vectors can never be written for the same
+		// model name.
+		if result.Embedded == 0 && len(vecs) > 0 && len(vecs[0]) > 0 {
+			if err := checkModelMismatch(ctx, st, model, len(vecs[0])); err != nil {
+				return result, err
+			}
+		}
+
 		for i, id := range validIDs {
 			if err := st.UpsertTopicEmbedding(ctx, id, model, cfg.Embeddings.Provider, vecs[i]); err != nil {
 				return result, fmt.Errorf("embeddings: store topic %d: %w", id, err)
@@ -134,13 +146,21 @@ type SemanticHit struct {
 
 // SemanticSearchOptions controls semantic search.
 type SemanticSearchOptions struct {
-	Query  string
-	Stream string
-	Limit  int
+	Query          string
+	Stream         string
+	Limit          int
+	// OnlyUnresolved excludes resolved topics from semantic search results.
+	// Mirrors the --unresolved flag available in FTS topic search.
+	OnlyUnresolved bool
 }
 
 // SemanticSearch performs a brute-force cosine similarity search over stored
 // topic embeddings.  It returns an error if no embeddings exist for the model.
+//
+// Filtering by Stream and OnlyUnresolved is pushed to the SQL layer via
+// FilteredEmbeddings so that the limit is applied to the correctly-scoped set.
+// Previously, filtering happened after a global sort+limit, which silently
+// discarded in-stream or unresolved topics that fell below the global cutoff.
 func SemanticSearch(ctx context.Context, st *store.Store, client embed.Client, opts SemanticSearchOptions) ([]SemanticHit, error) {
 	model := client.Model()
 	info, err := st.EmbeddingStats(ctx, model)
@@ -161,28 +181,31 @@ func SemanticSearch(ctx context.Context, st *store.Store, client embed.Client, o
 	}
 	qvec := qvecs[0]
 
-	// Load all vectors.
-	ids, vecs, err := st.AllEmbeddings(ctx, model)
+	// Load embeddings already filtered by stream and resolved status at the SQL
+	// layer.  This is the fix for the stream-filter and unresolved-filter bugs:
+	// sorting and limiting now operate on the correctly-scoped set, not on all
+	// topics globally.
+	entries, err := st.FilteredEmbeddings(ctx, model, opts.Stream, opts.OnlyUnresolved)
 	if err != nil {
-		return nil, fmt.Errorf("embeddings: load embeddings: %w", err)
+		return nil, fmt.Errorf("embeddings: load filtered embeddings: %w", err)
 	}
 
 	// Validate dimension consistency.
-	if len(vecs) > 0 && len(vecs[0]) != len(qvec) {
+	if len(entries) > 0 && len(entries[0].Vec) != len(qvec) {
 		return nil, fmt.Errorf(
 			"embeddings: dimension mismatch — stored vectors have dim=%d but query produced dim=%d.\n"+
 				"This usually means the model changed. Re-embed with:\n  zulcrawl embeddings backfill --force",
-			len(vecs[0]), len(qvec),
+			len(entries[0].Vec), len(qvec),
 		)
 	}
 
 	type scored struct {
-		id    int64
+		entry store.EmbeddingEntry
 		score float64
 	}
-	scores := make([]scored, len(ids))
-	for i, v := range vecs {
-		scores[i] = scored{id: ids[i], score: embed.CosineSimilarity(qvec, v)}
+	scores := make([]scored, len(entries))
+	for i, e := range entries {
+		scores[i] = scored{entry: e, score: embed.CosineSimilarity(qvec, e.Vec)}
 	}
 	sort.Slice(scores, func(i, j int) bool { return scores[i].score > scores[j].score })
 
@@ -194,26 +217,15 @@ func SemanticSearch(ctx context.Context, st *store.Store, client embed.Client, o
 		scores = scores[:limit]
 	}
 
-	// Fetch topic metadata for results.
 	out := make([]SemanticHit, 0, len(scores))
 	for _, s := range scores {
-		meta, err := st.TopicMeta(ctx, s.id)
-		if err == sql.ErrNoRows {
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("embeddings: get topic meta %d: %w", s.id, err)
-		}
-		if opts.Stream != "" && meta.StreamName != opts.Stream {
-			continue
-		}
 		out = append(out, SemanticHit{
-			TopicID:       s.id,
-			StreamName:    meta.StreamName,
-			TopicName:     meta.TopicName,
-			Resolved:      meta.Resolved,
-			MessageCount:  meta.MessageCount,
-			LastMessageAt: meta.LastMessageAt,
+			TopicID:       s.entry.TopicID,
+			StreamName:    s.entry.StreamName,
+			TopicName:     s.entry.TopicName,
+			Resolved:      s.entry.Resolved,
+			MessageCount:  s.entry.MessageCount,
+			LastMessageAt: s.entry.LastMessageAt,
 			Score:         s.score,
 		})
 	}

--- a/internal/embeddings/backfill_test.go
+++ b/internal/embeddings/backfill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/FtlC-ian/zulcrawl/internal/config"
@@ -163,5 +164,133 @@ func TestSemanticSearch_NoEmbeddings(t *testing.T) {
 	_, err := SemanticSearch(ctx, st, client, SemanticSearchOptions{Query: "test"})
 	if err == nil {
 		t.Fatal("expected error when no embeddings exist")
+	}
+}
+
+// seedTopicsMultiStream seeds topics across two streams (general / dev) and
+// returns (generalTopicIDs, devTopicIDs).  Both streams must exist in the db;
+// the standard setupEmbedTest already creates stream 10 ("general"), so here we
+// also add stream 11 ("dev").
+func seedTopicsMultiStream(t *testing.T, st *store.Store, ctx context.Context) ([]int64, []int64) {
+	t.Helper()
+	if err := st.UpsertStream(ctx, store.Stream{ID: 11, OrgID: 1, Name: "dev"}); err != nil {
+		t.Fatalf("UpsertStream dev: %v", err)
+	}
+	generalNames := []string{"general topic 1", "general topic 2", "general topic 3"}
+	devNames := []string{"dev topic alpha", "dev topic beta"}
+
+	msgID := int64(7000)
+	seedInStream := func(streamID int64, names []string) []int64 {
+		ids := make([]int64, 0, len(names))
+		for _, name := range names {
+			id, err := st.GetOrCreateTopic(ctx, 1, streamID, name)
+			if err != nil {
+				t.Fatalf("GetOrCreateTopic %q: %v", name, err)
+			}
+			if err := st.UpsertMessage(ctx, store.Message{
+				ID: msgID, OrgID: 1, StreamID: streamID, TopicID: id,
+				SenderID: 20, Content: "content " + name, ContentText: "content " + name,
+				Timestamp: "2026-04-29T10:00:00Z",
+			}); err != nil {
+				t.Fatalf("UpsertMessage for %q: %v", name, err)
+			}
+			msgID++
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return seedInStream(10, generalNames), seedInStream(11, devNames)
+}
+
+// TestSemanticSearch_StreamFilter verifies that the stream filter is applied
+// before sorting/limiting so that in-stream topics below a global cutoff are
+// not silently dropped.
+func TestSemanticSearch_StreamFilter(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	_, devIDs := seedTopicsMultiStream(t, st, ctx)
+
+	client := embed.NewFakeClient("fake-model", 8)
+	if _, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard); err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+
+	// Ask for only 2 results scoped to the "dev" stream; there are exactly 2
+	// dev topics so both should be returned regardless of global rank.
+	hits, err := SemanticSearch(ctx, st, client, SemanticSearchOptions{
+		Query:  "topic content",
+		Stream: "dev",
+		Limit:  2,
+	})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	if len(hits) != len(devIDs) {
+		t.Fatalf("expected %d hits for stream=dev, got %d", len(devIDs), len(hits))
+	}
+	for _, h := range hits {
+		if h.StreamName != "dev" {
+			t.Errorf("expected stream=dev, got %q", h.StreamName)
+		}
+	}
+}
+
+// TestSemanticSearch_OnlyUnresolved verifies that resolved topics are excluded
+// when OnlyUnresolved is true, mirroring the behaviour of FTS topic search.
+func TestSemanticSearch_OnlyUnresolved(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	// Seed three topics; mark the first one resolved.
+	ids := seedTopics(t, st, ctx, "resolved topic", "open topic A", "open topic B")
+	if err := st.SetTopicResolved(ctx, ids[0], true); err != nil {
+		t.Fatalf("mark resolved: %v", err)
+	}
+
+	client := embed.NewFakeClient("fake-model", 8)
+	if _, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard); err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+
+	hits, err := SemanticSearch(ctx, st, client, SemanticSearchOptions{
+		Query:          "topic",
+		Limit:          10,
+		OnlyUnresolved: true,
+	})
+	if err != nil {
+		t.Fatalf("SemanticSearch OnlyUnresolved: %v", err)
+	}
+	for _, h := range hits {
+		if h.Resolved {
+			t.Errorf("OnlyUnresolved=true but got resolved topic %q", h.TopicName)
+		}
+	}
+	if len(hits) != 2 {
+		t.Errorf("expected 2 unresolved hits, got %d", len(hits))
+	}
+}
+
+// TestBackfill_DimensionMismatchAfterFirstEmbed exercises the P1 fix:
+// when stored embeddings exist under a different dimension for the same model
+// name, Backfill must abort before writing any new vectors, even though
+// client.Dim() returns 0 on construction (i.e. before the first embed call).
+func TestBackfill_DimensionMismatchAfterFirstEmbed(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	// Seed and embed two topics with dim=4.
+	seedTopics(t, st, ctx, "existing A", "existing B")
+	clientDim4 := embed.NewFakeClient("shared-model", 4)
+	cfg.Embeddings.Model = "shared-model"
+	if _, err := Backfill(ctx, cfg, st, clientDim4, BackfillOptions{}, io.Discard); err != nil {
+		t.Fatalf("initial backfill: %v", err)
+	}
+
+	// Now add a new topic that hasn't been embedded yet.
+	seedTopics(t, st, ctx, "new topic")
+
+	// Try to backfill with a client that returns dim=8 vectors for the same model.
+	clientDim8 := embed.NewFakeClient("shared-model", 8)
+	_, err := Backfill(ctx, cfg, st, clientDim8, BackfillOptions{}, io.Discard)
+	if err == nil {
+		t.Fatal("expected dimension mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dimension mismatch") {
+		t.Errorf("expected 'dimension mismatch' in error, got: %v", err)
 	}
 }

--- a/internal/embeddings/backfill_test.go
+++ b/internal/embeddings/backfill_test.go
@@ -1,0 +1,167 @@
+package embeddings
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/FtlC-ian/zulcrawl/internal/config"
+	"github.com/FtlC-ian/zulcrawl/internal/embed"
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+)
+
+func setupEmbedTest(t *testing.T) (*store.Store, *config.Config, context.Context) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://example.com", "Example"); err != nil {
+		t.Fatalf("UpsertOrganization: %v", err)
+	}
+	if err := st.UpsertStream(ctx, store.Stream{ID: 10, OrgID: 1, Name: "general"}); err != nil {
+		t.Fatalf("UpsertStream: %v", err)
+	}
+	if err := st.UpsertUser(ctx, store.User{ID: 20, OrgID: 1, FullName: "Alice"}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	cfg := config.Default()
+	cfg.Embeddings.Enabled = true
+	cfg.Embeddings.Model = "fake-model"
+	cfg.Embeddings.BatchSize = 2
+	return st, cfg, ctx
+}
+
+func seedTopics(t *testing.T, st *store.Store, ctx context.Context, names ...string) []int64 {
+	t.Helper()
+	ids := make([]int64, 0, len(names))
+	for i, name := range names {
+		id, err := st.GetOrCreateTopic(ctx, 1, 10, name)
+		if err != nil {
+			t.Fatalf("GetOrCreateTopic %q: %v", name, err)
+		}
+		// Insert one message so TopicText returns something.
+		if err := st.UpsertMessage(ctx, store.Message{
+			ID: int64(5000 + i), OrgID: 1, StreamID: 10, TopicID: id,
+			SenderID: 20, Content: "msg " + name, ContentText: "msg " + name,
+			Timestamp: "2026-04-29T10:00:00Z",
+		}); err != nil {
+			t.Fatalf("UpsertMessage for %q: %v", name, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func TestBackfill_AllTopicsEmbedded(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	_ = seedTopics(t, st, ctx, "topic A", "topic B", "topic C")
+
+	client := embed.NewFakeClient("fake-model", 8)
+	result, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	if result.Embedded != 3 {
+		t.Errorf("expected Embedded=3, got %d", result.Embedded)
+	}
+	if result.Skipped != 0 {
+		t.Errorf("expected Skipped=0, got %d", result.Skipped)
+	}
+}
+
+func TestBackfill_AlreadyEmbedded(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	ids := seedTopics(t, st, ctx, "topic X", "topic Y")
+
+	client := embed.NewFakeClient("fake-model", 4)
+	// First run.
+	_, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard)
+	if err != nil {
+		t.Fatalf("first Backfill: %v", err)
+	}
+
+	// Verify embedded.
+	missing, _ := st.TopicsNeedingEmbedding(ctx, "fake-model", 0)
+	if len(missing) != 0 {
+		t.Fatalf("expected 0 missing after backfill, got %d", len(missing))
+	}
+	_ = ids
+
+	// Second run should embed 0 additional.
+	result2, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard)
+	if err != nil {
+		t.Fatalf("second Backfill: %v", err)
+	}
+	if result2.Embedded != 0 {
+		t.Errorf("second run should embed 0, got %d", result2.Embedded)
+	}
+}
+
+func TestBackfill_Disabled(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	cfg.Embeddings.Enabled = false
+	client := embed.NewFakeClient("fake-model", 4)
+	_, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error when embeddings disabled")
+	}
+}
+
+func TestBackfill_Limit(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	seedTopics(t, st, ctx, "t1", "t2", "t3", "t4", "t5")
+
+	client := embed.NewFakeClient("fake-model", 4)
+	result, err := Backfill(ctx, cfg, st, client, BackfillOptions{Limit: 3}, io.Discard)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	if result.Embedded != 3 {
+		t.Errorf("expected Embedded=3 with limit=3, got %d", result.Embedded)
+	}
+}
+
+func TestSemanticSearch_Basic(t *testing.T) {
+	st, cfg, ctx := setupEmbedTest(t)
+	seedTopics(t, st, ctx, "deployment", "onboarding", "random banter")
+
+	client := embed.NewFakeClient("fake-model", 8)
+
+	// Backfill first.
+	if _, err := Backfill(ctx, cfg, st, client, BackfillOptions{}, io.Discard); err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+
+	hits, err := SemanticSearch(ctx, st, client, SemanticSearchOptions{
+		Query: "deploy release",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected at least one hit")
+	}
+	// All scores should be in [-1, 1].
+	for _, h := range hits {
+		if h.Score < -1.1 || h.Score > 1.1 {
+			t.Errorf("unexpected score %f for topic %q", h.Score, h.TopicName)
+		}
+	}
+}
+
+func TestSemanticSearch_NoEmbeddings(t *testing.T) {
+	st, _, ctx := setupEmbedTest(t)
+	client := embed.NewFakeClient("fake-model", 4)
+	_, err := SemanticSearch(ctx, st, client, SemanticSearchOptions{Query: "test"})
+	if err == nil {
+		t.Fatal("expected error when no embeddings exist")
+	}
+}

--- a/internal/store/embeddings.go
+++ b/internal/store/embeddings.go
@@ -245,6 +245,67 @@ func (s *Store) DeleteEmbeddingsByModel(ctx context.Context, model string) error
 	return err
 }
 
+// EmbeddingEntry combines a stored vector with its topic metadata.
+// Used by FilteredEmbeddings for stream/resolved-scoped semantic search.
+type EmbeddingEntry struct {
+	TopicID       int64
+	StreamName    string
+	TopicName     string
+	Resolved      bool
+	MessageCount  int
+	LastMessageAt string
+	Vec           []float32
+}
+
+// FilteredEmbeddings returns stored embeddings for model, filtered by optional
+// stream name and resolved status. Filtering is applied at the SQL layer so
+// that callers can limit results to a correctly-scoped set without a post-filter
+// that would silently discard relevant in-stream topics below a global cutoff.
+func (s *Store) FilteredEmbeddings(ctx context.Context, model, stream string, onlyUnresolved bool) ([]EmbeddingEntry, error) {
+	q := `
+SELECT te.topic_id, st.name, t.name, t.resolved, t.message_count,
+       COALESCE(t.last_message_at, ''), te.vector
+FROM topic_embeddings te
+JOIN topics t  ON t.id  = te.topic_id
+JOIN streams st ON st.id = t.stream_id
+WHERE te.model = ?`
+	args := []any{model}
+	if stream != "" {
+		q += " AND st.name = ?"
+		args = append(args, stream)
+	}
+	if onlyUnresolved {
+		q += " AND t.resolved = 0"
+	}
+	q += " ORDER BY te.topic_id ASC"
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []EmbeddingEntry
+	for rows.Next() {
+		var e EmbeddingEntry
+		var blob []byte
+		var resolved int
+		if err := rows.Scan(
+			&e.TopicID, &e.StreamName, &e.TopicName,
+			&resolved, &e.MessageCount, &e.LastMessageAt, &blob,
+		); err != nil {
+			return nil, err
+		}
+		e.Resolved = resolved == 1
+		v, err := decodeVec(blob)
+		if err != nil {
+			return nil, fmt.Errorf("store: decode embedding for topic %d: %w", e.TopicID, err)
+		}
+		e.Vec = v
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // TopicMeta returns lightweight metadata for a single topic by ID.
 func (s *Store) TopicMeta(ctx context.Context, topicID int64) (*TopicMetaRow, error) {
 	var r TopicMetaRow

--- a/internal/store/embeddings.go
+++ b/internal/store/embeddings.go
@@ -1,0 +1,285 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// EmbeddingRecord represents one stored embedding row.
+type EmbeddingRecord struct {
+	TopicID   int64
+	Model     string
+	Provider  string
+	Dimension int
+	Vec       []float32
+}
+
+// embeddingSchema is appended to InitSchema.
+const embeddingSchema = `
+-- topic_embeddings stores one normalised float32 vector per (topic, model).
+-- Vectors are stored as little-endian IEEE-754 bytes.
+-- A unique constraint on (topic_id, model) makes re-embedding idempotent.
+CREATE TABLE IF NOT EXISTS topic_embeddings (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    topic_id   INTEGER NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    model      TEXT    NOT NULL,
+    provider   TEXT    NOT NULL DEFAULT 'ollama',
+    dimension  INTEGER NOT NULL,
+    vector     BLOB    NOT NULL,
+    indexed_at TEXT    NOT NULL,
+    UNIQUE(topic_id, model)
+);
+CREATE INDEX IF NOT EXISTS idx_topic_embeddings_topic ON topic_embeddings(topic_id);
+CREATE INDEX IF NOT EXISTS idx_topic_embeddings_model ON topic_embeddings(model);
+`
+
+// InitEmbeddingSchema creates the embeddings table if it does not exist.
+// It is called by InitSchema; callers should not need to invoke it directly.
+func (s *Store) InitEmbeddingSchema(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, embeddingSchema)
+	return err
+}
+
+// UpsertTopicEmbedding stores or replaces a topic embedding.
+// indexed_at is set to the current UTC timestamp.
+func (s *Store) UpsertTopicEmbedding(ctx context.Context, topicID int64, model, provider string, vec []float32) error {
+	if len(vec) == 0 {
+		return fmt.Errorf("store: cannot upsert empty embedding for topic %d", topicID)
+	}
+	blob := encodeVec(vec)
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO topic_embeddings(topic_id, model, provider, dimension, vector, indexed_at)
+VALUES (?, ?, ?, ?, ?, datetime('now'))
+ON CONFLICT(topic_id, model) DO UPDATE SET
+    provider   = excluded.provider,
+    dimension  = excluded.dimension,
+    vector     = excluded.vector,
+    indexed_at = excluded.indexed_at`,
+		topicID, model, provider, len(vec), blob,
+	)
+	return err
+}
+
+// GetTopicEmbedding retrieves the stored embedding for a topic and model.
+// Returns sql.ErrNoRows if none exists.
+func (s *Store) GetTopicEmbedding(ctx context.Context, topicID int64, model string) (*EmbeddingRecord, error) {
+	var rec EmbeddingRecord
+	var blob []byte
+	err := s.db.QueryRowContext(ctx, `
+SELECT topic_id, model, provider, dimension, vector
+FROM topic_embeddings
+WHERE topic_id = ? AND model = ?`, topicID, model).Scan(
+		&rec.TopicID, &rec.Model, &rec.Provider, &rec.Dimension, &blob,
+	)
+	if err != nil {
+		return nil, err
+	}
+	vec, err := decodeVec(blob)
+	if err != nil {
+		return nil, fmt.Errorf("store: decode embedding for topic %d: %w", topicID, err)
+	}
+	rec.Vec = vec
+	return &rec, nil
+}
+
+// EmbeddingModelInfo describes the model and dimension currently stored.
+type EmbeddingModelInfo struct {
+	Model    string
+	Provider string
+	Dim      int
+	Count    int64
+}
+
+// EmbeddingStats returns stored model info for a given model name, or nil if none.
+func (s *Store) EmbeddingStats(ctx context.Context, model string) (*EmbeddingModelInfo, error) {
+	var info EmbeddingModelInfo
+	err := s.db.QueryRowContext(ctx, `
+SELECT model, provider, dimension, COUNT(*) AS cnt
+FROM topic_embeddings
+WHERE model = ?
+GROUP BY model, provider, dimension`, model).Scan(
+		&info.Model, &info.Provider, &info.Dim, &info.Count,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// TopicsNeedingEmbedding returns topic IDs that have no embedding for model,
+// up to limit rows. Passing limit ≤ 0 returns all.
+func (s *Store) TopicsNeedingEmbedding(ctx context.Context, model string, limit int) ([]int64, error) {
+	q := `
+SELECT t.id
+FROM topics t
+WHERE NOT EXISTS (
+    SELECT 1 FROM topic_embeddings e WHERE e.topic_id = t.id AND e.model = ?
+)
+ORDER BY t.id ASC`
+	var args []any
+	args = append(args, model)
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// TopicText returns a concatenated text representation of a topic suitable for
+// embedding: topic name followed by a sample of message content.
+// sampleMessages limits how many messages are included; 0 means 50.
+func (s *Store) TopicText(ctx context.Context, topicID int64, sampleMessages int) (string, error) {
+	if sampleMessages <= 0 {
+		sampleMessages = 50
+	}
+	// Get topic name and stream name.
+	var topicName, streamName string
+	err := s.db.QueryRowContext(ctx, `
+SELECT t.name, st.name
+FROM topics t
+JOIN streams st ON st.id = t.stream_id
+WHERE t.id = ?`, topicID).Scan(&topicName, &streamName)
+	if err != nil {
+		return "", fmt.Errorf("store: topic text topic %d: %w", topicID, err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+SELECT content_text
+FROM messages
+WHERE topic_id = ?
+ORDER BY id ASC
+LIMIT ?`, topicID, sampleMessages)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var sb []string
+	sb = append(sb, "#"+streamName+" > "+topicName)
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return "", err
+		}
+		if t != "" {
+			sb = append(sb, t)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	result := ""
+	for i, s := range sb {
+		if i > 0 {
+			result += "\n"
+		}
+		result += s
+	}
+	return result, nil
+}
+
+// AllEmbeddings returns all stored embeddings for the given model, for brute-force
+// cosine search. Returns (topicIDs, vectors).
+func (s *Store) AllEmbeddings(ctx context.Context, model string) ([]int64, [][]float32, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT topic_id, vector
+FROM topic_embeddings
+WHERE model = ?
+ORDER BY topic_id ASC`, model)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	var vecs [][]float32
+	for rows.Next() {
+		var id int64
+		var blob []byte
+		if err := rows.Scan(&id, &blob); err != nil {
+			return nil, nil, err
+		}
+		v, err := decodeVec(blob)
+		if err != nil {
+			return nil, nil, fmt.Errorf("store: decode embedding for topic %d: %w", id, err)
+		}
+		ids = append(ids, id)
+		vecs = append(vecs, v)
+	}
+	return ids, vecs, rows.Err()
+}
+
+// TopicMetaRow holds minimal metadata about a topic for display.
+type TopicMetaRow struct {
+	TopicID       int64
+	StreamName    string
+	TopicName     string
+	Resolved      bool
+	MessageCount  int
+	LastMessageAt string
+}
+
+// DeleteEmbeddingsByModel removes all stored embeddings for the given model.
+// Used by 'embeddings backfill --force' to trigger a full re-embed.
+func (s *Store) DeleteEmbeddingsByModel(ctx context.Context, model string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM topic_embeddings WHERE model = ?`, model)
+	return err
+}
+
+// TopicMeta returns lightweight metadata for a single topic by ID.
+func (s *Store) TopicMeta(ctx context.Context, topicID int64) (*TopicMetaRow, error) {
+	var r TopicMetaRow
+	var resolved int
+	err := s.db.QueryRowContext(ctx, `
+SELECT t.id, st.name, t.name, t.resolved, t.message_count, COALESCE(t.last_message_at,'')
+FROM topics t
+JOIN streams st ON st.id = t.stream_id
+WHERE t.id = ?`, topicID).Scan(
+		&r.TopicID, &r.StreamName, &r.TopicName, &resolved, &r.MessageCount, &r.LastMessageAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	r.Resolved = resolved == 1
+	return &r, nil
+}
+
+func encodeVec(v []float32) []byte {
+	b := make([]byte, len(v)*4)
+	for i, x := range v {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(x))
+	}
+	return b
+}
+
+// decodeVec deserialises a float32 vector from little-endian bytes.
+func decodeVec(b []byte) ([]float32, error) {
+	if len(b)%4 != 0 {
+		return nil, fmt.Errorf("byte length %d not a multiple of 4", len(b))
+	}
+	v := make([]float32, len(b)/4)
+	for i := range v {
+		bits := binary.LittleEndian.Uint32(b[i*4:])
+		v[i] = math.Float32frombits(bits)
+	}
+	return v, nil
+}

--- a/internal/store/embeddings_test.go
+++ b/internal/store/embeddings_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestUpsertAndGetTopicEmbedding(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "embed test topic")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+	if err := st.UpsertTopicEmbedding(ctx, topicID, "test-model", "ollama", vec); err != nil {
+		t.Fatalf("UpsertTopicEmbedding: %v", err)
+	}
+
+	rec, err := st.GetTopicEmbedding(ctx, topicID, "test-model")
+	if err != nil {
+		t.Fatalf("GetTopicEmbedding: %v", err)
+	}
+	if len(rec.Vec) != len(vec) {
+		t.Fatalf("vec length: want %d got %d", len(vec), len(rec.Vec))
+	}
+	for i := range vec {
+		if rec.Vec[i] != vec[i] {
+			t.Errorf("vec[%d]: want %v got %v", i, vec[i], rec.Vec[i])
+		}
+	}
+}
+
+func TestUpsertTopicEmbeddingIdempotent(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, _ := st.GetOrCreateTopic(ctx, 1, 10, "embed idempotent")
+
+	vec1 := []float32{0.1, 0.9, 0.0, 0.0}
+	vec2 := []float32{0.0, 0.0, 0.6, 0.8}
+
+	if err := st.UpsertTopicEmbedding(ctx, topicID, "m1", "ollama", vec1); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := st.UpsertTopicEmbedding(ctx, topicID, "m1", "ollama", vec2); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rec, _ := st.GetTopicEmbedding(ctx, topicID, "m1")
+	if rec.Vec[2] != vec2[2] {
+		t.Errorf("expected updated vector, got old value")
+	}
+}
+
+func TestGetTopicEmbedding_NotFound(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, _ := st.GetOrCreateTopic(ctx, 1, 10, "embed notfound")
+	_, err := st.GetTopicEmbedding(ctx, topicID, "nonexistent-model")
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestTopicsNeedingEmbedding(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	t1, _ := st.GetOrCreateTopic(ctx, 1, 10, "topic 1")
+	t2, _ := st.GetOrCreateTopic(ctx, 1, 10, "topic 2")
+	t3, _ := st.GetOrCreateTopic(ctx, 1, 10, "topic 3")
+
+	// Embed only t1 and t2.
+	_ = st.UpsertTopicEmbedding(ctx, t1, "m1", "ollama", []float32{1, 0})
+	_ = st.UpsertTopicEmbedding(ctx, t2, "m1", "ollama", []float32{0, 1})
+
+	// t3 should be missing.
+	missing, err := st.TopicsNeedingEmbedding(ctx, "m1", 0)
+	if err != nil {
+		t.Fatalf("TopicsNeedingEmbedding: %v", err)
+	}
+	if len(missing) != 1 || missing[0] != t3 {
+		t.Errorf("expected [%d], got %v", t3, missing)
+	}
+}
+
+func TestEmbeddingStats(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	t1, _ := st.GetOrCreateTopic(ctx, 1, 10, "stats t1")
+	t2, _ := st.GetOrCreateTopic(ctx, 1, 10, "stats t2")
+
+	_ = st.UpsertTopicEmbedding(ctx, t1, "nomic-embed-text-v2-moe", "ollama", []float32{1, 0, 0})
+	_ = st.UpsertTopicEmbedding(ctx, t2, "nomic-embed-text-v2-moe", "ollama", []float32{0, 1, 0})
+
+	info, err := st.EmbeddingStats(ctx, "nomic-embed-text-v2-moe")
+	if err != nil {
+		t.Fatalf("EmbeddingStats: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil info")
+	}
+	if info.Count != 2 {
+		t.Errorf("expected count=2, got %d", info.Count)
+	}
+	if info.Dim != 3 {
+		t.Errorf("expected dim=3, got %d", info.Dim)
+	}
+}
+
+func TestAllEmbeddings(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	t1, _ := st.GetOrCreateTopic(ctx, 1, 10, "all t1")
+	t2, _ := st.GetOrCreateTopic(ctx, 1, 10, "all t2")
+
+	v1 := []float32{1, 0}
+	v2 := []float32{0, 1}
+	_ = st.UpsertTopicEmbedding(ctx, t1, "m", "ollama", v1)
+	_ = st.UpsertTopicEmbedding(ctx, t2, "m", "ollama", v2)
+
+	ids, vecs, err := st.AllEmbeddings(ctx, "m")
+	if err != nil {
+		t.Fatalf("AllEmbeddings: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 embeddings, got %d", len(ids))
+	}
+	_ = vecs
+}
+
+func TestTopicText(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, _ := st.GetOrCreateTopic(ctx, 1, 10, "text topic")
+
+	_ = st.UpsertMessage(ctx, Message{
+		ID: 9001, OrgID: 1, StreamID: 10, TopicID: topicID, SenderID: 20,
+		Content: "hello world", ContentText: "hello world",
+		Timestamp: "2026-04-29T10:00:00Z",
+	})
+
+	text, err := st.TopicText(ctx, topicID, 10)
+	if err != nil {
+		t.Fatalf("TopicText: %v", err)
+	}
+	if text == "" {
+		t.Error("expected non-empty topic text")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -322,6 +322,17 @@ func topicResolved(name string) bool {
 	return strings.HasPrefix(t, "✔") || strings.HasPrefix(strings.ToLower(t), "[resolved]")
 }
 
+// SetTopicResolved updates the resolved flag for a single topic by ID.
+// Primarily used in tests; also available for manual resolution overrides.
+func (s *Store) SetTopicResolved(ctx context.Context, topicID int64, resolved bool) error {
+	v := 0
+	if resolved {
+		v = 1
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE topics SET resolved=? WHERE id=?`, v, topicID)
+	return err
+}
+
 func (s *Store) GetOrCreateTopic(ctx context.Context, orgID, streamID int64, name string) (int64, error) {
 	if name == "" {
 		name = "(no topic)"

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -195,9 +195,11 @@ END;
 		return err
 	}
 	if ftsMigrated {
-		return s.ReindexFTS(ctx)
+		if err := s.ReindexFTS(ctx); err != nil {
+			return err
+		}
 	}
-	return nil
+	return s.InitEmbeddingSchema(ctx)
 }
 
 func (s *Store) prepareFTSMigration(ctx context.Context) (bool, error) {


### PR DESCRIPTION
Closes #16

## Summary

Adds optional local Ollama embeddings for semantic topic search. **Disabled by default** — no embedding calls are made unless `[embeddings] enabled = true` is set in config.

## What works without Ollama

Everything that worked before still works. All existing commands, tests, and behavior are unchanged when embeddings are disabled (the default).

```bash
go test ./...   # all pass, no Ollama needed
go build ./...  # clean build
```

## What requires a pulled model

```bash
ollama serve
ollama pull nomic-embed-text-v2-moe

zulcrawl embeddings backfill
zulcrawl topics search --semantic "your query here"
```

## New files

| Package | Purpose |
|---------|---------|
| `internal/embed/client.go` | OllamaClient: batched `/api/embed`, normalised float32 vectors, `CheckAvailable()` |
| `internal/embed/fake.go` | FakeClient for tests — no Ollama needed in CI |
| `internal/embeddings/backfill.go` | Incremental backfill + brute-force cosine `SemanticSearch()` |
| `internal/store/embeddings.go` | `topic_embeddings` table + all store methods |

## New commands

```bash
# Build/update embeddings (incremental by default)
zulcrawl embeddings backfill
zulcrawl embeddings backfill --force   # re-embed after model change

# Coverage check
zulcrawl embeddings status

# Semantic search (--semantic flag; FTS default is unchanged)
zulcrawl topics search --semantic "deploy pipeline"
```

## Schema

New table `topic_embeddings` (migration-safe, created in `InitSchema`):
```sql
CREATE TABLE IF NOT EXISTS topic_embeddings (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    topic_id   INTEGER NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
    model      TEXT    NOT NULL,
    provider   TEXT    NOT NULL DEFAULT 'ollama',
    dimension  INTEGER NOT NULL,
    vector     BLOB    NOT NULL,  -- little-endian float32 × dimension
    indexed_at TEXT    NOT NULL,
    UNIQUE(topic_id, model)
);
```

## Safety guarantees

- **Dimension mismatch** → clear error + re-embed guidance, not silent mixed vectors
- **Ollama unavailable** → helpful error (is Ollama running? model pulled?)
- **Model not pulled** → lists available models and suggests `ollama pull`
- **`--force`** drops and rebuilds embeddings for the model; does not touch other data

## Deferred (not in this PR)

- MLX/CoreML / other providers
- sqlite-vec / HNSW (brute-force cosine is the stated target)
- Hybrid FTS+semantic score fusion (currently separate modes via `--semantic` flag)
- Remote attachment fetching

## Verification

```
go test ./...          # all pass
go test -race ./...    # all pass
govulncheck ./...      # No vulnerabilities found
go build ./...         # clean
```