### PR TITLE
feat: cache Zulip attachment media

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Verify module files are tidy

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 - Cobra CLI commands:
   - `init`
   - `doctor`
-  - `sync --full --streams --since [--quiet]`
+  - `sync --full --streams --since [--quiet] [--with-media]`
   - `search`
   - `topics` — list topics or topic-level hybrid search
   - `topics search` — hybrid search: FTS on topic names + message content (see below)
   - `stats`
   - `sql`
   - `messages` — direct archive slice queries (see below)
+  - `attachments` / `attachments fetch` — list indexed uploads and cache Zulip media locally
   - `backfill-indexes` — rebuild mention/attachment indexes for existing messages
   - `embeddings backfill` — build/update Ollama topic embeddings (disabled by default)
   - `embeddings status` — show embedding coverage
@@ -27,17 +28,26 @@
 - Topic-level hybrid search: two-leg FTS (topic names + message content) with activity/recency scoring
 - Mention and attachment indexes parsed from rendered HTML
 
-## Attachment indexing — current scope
+## Attachment indexing and local media cache
 
-Attachment indexing covers **text already present in the Zulip-rendered HTML** of
-each message — inline previews and short snippets that Zulip embeds in the
-rendered `<div class="message_inline_ref">` block.  It does **not** fetch or
-parse the actual uploaded file contents (PDFs, images, Office documents, etc.).
-For text-heavy attachments the best coverage comes from users quoting or
-summarising content in the message body itself.
+Attachment indexing covers `/user_uploads/...` links found in Zulip-rendered
+message HTML, plus any text already present in inline preview blocks. `zulcrawl`
+can also download the original upload bytes into a **local-only** cache using the
+same Zulip API credentials:
 
-Full file-content extraction (downloading from `/user_uploads/…` and parsing
-the file bytes) is a planned future enhancement and is **not implemented**.
+```bash
+zulcrawl attachments                 # list indexed attachments and cache status
+zulcrawl attachments --status pending --stream engineering
+zulcrawl attachments fetch           # download pending/error uploads
+zulcrawl sync --with-media           # sync, then fetch media
+```
+
+Cached media defaults to `~/.zulcrawl/media` and is tracked in SQLite with path,
+status, fetched timestamp, content type, byte count, and last error. It is never
+published or uploaded by zulcrawl.
+
+Full file-content extraction/parsing (PDFs, images, Office documents, etc.) is
+still a future enhancement; downloaded media is cached as bytes only.
 
 ## Build
 
@@ -57,6 +67,9 @@ api_key = ""
 
 [database]
 path = "~/.zulcrawl/zulcrawl.db"
+
+[media]
+cache_dir = "~/.zulcrawl/media"
 
 [sync]
 concurrency = 4
@@ -90,6 +103,13 @@ zulcrawl sync --since 2026-01-01
 
 # Sync silently (suppress progress lines, show only final summary or errors)
 zulcrawl sync --quiet
+
+# Sync and then cache indexed Zulip upload bytes locally
+zulcrawl sync --with-media
+
+# List and fetch attachment media
+zulcrawl attachments --status pending
+zulcrawl attachments fetch
 
 # Search
 zulcrawl search "database migration"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/FtlC-ian/zulcrawl
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/pelletier/go-toml/v2 v2.3.0

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/FtlC-ian/zulcrawl/internal/embed"
 	"github.com/FtlC-ian/zulcrawl/internal/embeddings"
 	"github.com/FtlC-ian/zulcrawl/internal/lock"
+	"github.com/FtlC-ian/zulcrawl/internal/media"
 	"github.com/FtlC-ian/zulcrawl/internal/search"
 	"github.com/FtlC-ian/zulcrawl/internal/store"
 	"github.com/FtlC-ian/zulcrawl/internal/syncer"
@@ -41,6 +42,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(statsCmd(loadCfg))
 	root.AddCommand(sqlCmd(loadCfg))
 	root.AddCommand(messagesCmd(loadCfg))
+	root.AddCommand(attachmentsCmd(loadCfg))
 	root.AddCommand(backfillIndexesCmd(loadCfg))
 	root.AddCommand(embeddingsCmd(loadCfg))
 	return root
@@ -152,6 +154,7 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	var since string
 	var streams string
 	var quiet bool
+	var withMedia bool
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync streams/messages from Zulip",
@@ -212,6 +215,13 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 			if err := sy.Sync(ctx, syncer.Options{Full: full, Streams: include, Since: since}); err != nil {
 				return err
 			}
+			if withMedia {
+				res, err := media.FetchPending(ctx, st, api, media.FetchOptions{CacheDir: cfg.MediaCacheDir()})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "media fetch: %d fetched, %d skipped, %d failed\n", res.Fetched, res.Skipped, res.Failed)
+			}
 			fmt.Printf("sync complete in %s\n", time.Since(start).Round(time.Millisecond))
 			return nil
 		},
@@ -220,6 +230,7 @@ func syncCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
 	cmd.Flags().StringVar(&streams, "streams", "", "comma-separated stream names")
 	cmd.Flags().StringVar(&since, "since", "", "only include messages since date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output (only print final summary or errors)")
+	cmd.Flags().BoolVar(&withMedia, "with-media", false, "download indexed Zulip attachment media into the local cache after sync")
 	return cmd
 }
 
@@ -609,6 +620,103 @@ The default safety limit is 200 messages; use --limit or --all to override.`,
 	cmd.Flags().IntVar(&last, "last", 0, "return the N most recent messages (oldest-first output)")
 	cmd.Flags().IntVar(&limit, "limit", 200, "maximum messages to return (default 200)")
 	cmd.Flags().BoolVar(&all, "all", false, "remove safety limit and return all matching messages")
+	return cmd
+}
+
+func attachmentsCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var stream string
+	var topic string
+	var status string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "attachments",
+		Short: "List indexed Zulip attachments and local media cache status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			if err := st.InitSchema(cmd.Context()); err != nil {
+				return err
+			}
+			rows, err := st.ListAttachments(cmd.Context(), store.AttachmentFilter{Stream: stream, Topic: topic, Status: status, Limit: limit})
+			if err != nil {
+				return err
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No attachments found.")
+				return nil
+			}
+			for _, a := range rows {
+				stText := a.MediaStatus
+				if stText == "" {
+					stText = "pending"
+				}
+				name := a.FileName
+				if name == "" {
+					name = a.Title
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\tmsg:%d\t%s\t#%s > %s\t%s\t%s\n", a.ID, a.MessageID, stText, a.StreamName, a.TopicName, name, a.URL)
+				if a.MediaPath != "" || a.MediaError != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "\tpath:%s\tbytes:%d\terror:%s\n", a.MediaPath, a.MediaBytes, a.MediaError)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&stream, "stream", "", "filter by stream name")
+	cmd.Flags().StringVar(&topic, "topic", "", "filter by topic name")
+	cmd.Flags().StringVar(&status, "status", "", "filter by media status: pending, fetched, error, all")
+	cmd.Flags().IntVar(&limit, "limit", 100, "row limit")
+	cmd.AddCommand(attachmentsFetchCmd(loadCfg))
+	return cmd
+}
+
+func attachmentsFetchCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var limit int
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "fetch",
+		Short: "Download indexed Zulip /user_uploads/ attachments into the local cache",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			if err := cfg.ValidateAuth(); err != nil {
+				return err
+			}
+			lockPath := cfg.DBPath() + ".lock"
+			l, err := lock.Acquire(lockPath)
+			if err != nil {
+				return err
+			}
+			defer l.Release()
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+			if err := st.InitSchema(cmd.Context()); err != nil {
+				return err
+			}
+			api := zulip.NewClient(cfg.Zulip.URL, cfg.Zulip.Email, cfg.Zulip.APIKey)
+			res, err := media.FetchPending(cmd.Context(), st, api, media.FetchOptions{CacheDir: cfg.MediaCacheDir(), Limit: limit, Force: force})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "media fetch: %d fetched, %d skipped, %d failed\n", res.Fetched, res.Skipped, res.Failed)
+			fmt.Fprintf(cmd.OutOrStdout(), "cache: %s\n", cfg.MediaCacheDir())
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0, "maximum attachments to fetch (default all pending/error)")
+	cmd.Flags().BoolVar(&force, "force", false, "refetch attachments even if already fetched")
 	return cmd
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	Database struct {
 		Path string `toml:"path"`
 	} `toml:"database"`
+	Media struct {
+		// CacheDir is a local-only cache for Zulip /user_uploads/ attachments.
+		// Cached private media is never published by zulcrawl.
+		CacheDir string `toml:"cache_dir"`
+	} `toml:"media"`
 	Sync struct {
 		Concurrency    int      `toml:"concurrency"`
 		Streams        []string `toml:"streams"`
@@ -58,6 +63,7 @@ type Config struct {
 func Default() *Config {
 	c := &Config{}
 	c.Database.Path = "~/.zulcrawl/zulcrawl.db"
+	c.Media.CacheDir = "~/.zulcrawl/media"
 	c.Sync.Concurrency = 4
 	c.Sync.Streams = []string{}
 	c.Sync.ExcludeStreams = []string{"social", "random"}
@@ -118,6 +124,9 @@ func (c *Config) Normalize() {
 	if c.Database.Path == "" {
 		c.Database.Path = "~/.zulcrawl/zulcrawl.db"
 	}
+	if c.Media.CacheDir == "" {
+		c.Media.CacheDir = "~/.zulcrawl/media"
+	}
 }
 
 func (c *Config) ApplyEnv() {
@@ -149,6 +158,10 @@ func (c *Config) Save(path string) error {
 
 func (c *Config) DBPath() string {
 	return ExpandPath(c.Database.Path)
+}
+
+func (c *Config) MediaCacheDir() string {
+	return ExpandPath(c.Media.CacheDir)
 }
 
 func (c *Config) ValidateEmbeddings() error {

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -1,0 +1,159 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+	"github.com/FtlC-ian/zulcrawl/internal/zulip"
+)
+
+const StatusFetched = "fetched"
+const StatusError = "error"
+
+// FetchOptions controls attachment media downloads.
+type FetchOptions struct {
+	CacheDir string
+	Limit    int
+	Force    bool
+}
+
+type FetchResult struct {
+	Fetched int
+	Skipped int
+	Failed  int
+}
+
+// FetchPending downloads locally indexed Zulip /user_uploads/ attachments into
+// the configured cache directory. It only reads private media into local files;
+// nothing is published or uploaded elsewhere.
+func FetchPending(ctx context.Context, st *store.Store, api *zulip.Client, opts FetchOptions) (FetchResult, error) {
+	var res FetchResult
+	if strings.TrimSpace(opts.CacheDir) == "" {
+		return res, fmt.Errorf("cache dir is required")
+	}
+	if err := os.MkdirAll(opts.CacheDir, 0o700); err != nil {
+		return res, err
+	}
+
+	rows, err := st.ListAttachments(ctx, store.AttachmentFilter{Status: fetchStatus(opts.Force), Limit: opts.Limit})
+	if err != nil {
+		return res, err
+	}
+	for _, a := range rows {
+		if ctx.Err() != nil {
+			return res, ctx.Err()
+		}
+		if !strings.HasPrefix(a.URL, "/user_uploads/") {
+			res.Skipped++
+			continue
+		}
+		rel, err := safeRelativePath(a.URL, a.FileName)
+		if err != nil {
+			res.Failed++
+			_ = st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{Status: StatusError, Error: err.Error(), FetchedAt: time.Now().UTC().Format(time.RFC3339)})
+			continue
+		}
+		dest := filepath.Join(opts.CacheDir, rel)
+		if !strings.HasPrefix(dest, filepath.Clean(opts.CacheDir)+string(os.PathSeparator)) && filepath.Clean(dest) != filepath.Clean(opts.CacheDir) {
+			res.Failed++
+			_ = st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{Status: StatusError, Error: "unsafe cache path", FetchedAt: time.Now().UTC().Format(time.RFC3339)})
+			continue
+		}
+		if !opts.Force {
+			if _, err := os.Stat(dest); err == nil && a.MediaStatus == StatusFetched {
+				res.Skipped++
+				continue
+			}
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			return res, err
+		}
+		tmp := dest + ".tmp"
+		body, contentType, err := api.Download(ctx, a.URL)
+		if err != nil {
+			res.Failed++
+			_ = st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{Status: StatusError, Path: dest, Error: err.Error(), FetchedAt: time.Now().UTC().Format(time.RFC3339)})
+			continue
+		}
+		bytes, copyErr := writeBody(tmp, body)
+		closeErr := body.Close()
+		if copyErr != nil {
+			_ = os.Remove(tmp)
+			res.Failed++
+			_ = st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{Status: StatusError, Path: dest, Error: copyErr.Error(), FetchedAt: time.Now().UTC().Format(time.RFC3339)})
+			continue
+		}
+		if closeErr != nil {
+			_ = os.Remove(tmp)
+			res.Failed++
+			_ = st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{Status: StatusError, Path: dest, Error: closeErr.Error(), FetchedAt: time.Now().UTC().Format(time.RFC3339)})
+			continue
+		}
+		if err := os.Rename(tmp, dest); err != nil {
+			_ = os.Remove(tmp)
+			return res, err
+		}
+		if contentType == "" {
+			contentType = a.ContentType
+		}
+		if err := st.UpdateAttachmentMedia(ctx, a.ID, store.AttachmentMediaUpdate{
+			Path:        dest,
+			Status:      StatusFetched,
+			FetchedAt:   time.Now().UTC().Format(time.RFC3339),
+			ContentType: contentType,
+			Bytes:       bytes,
+			Error:       "",
+		}); err != nil {
+			return res, err
+		}
+		res.Fetched++
+	}
+	return res, nil
+}
+
+func fetchStatus(force bool) string {
+	if force {
+		return ""
+	}
+	return "pending"
+}
+
+func writeBody(path string, body io.Reader) (int64, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, err
+	}
+	n, copyErr := io.Copy(f, body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return n, copyErr
+	}
+	return n, closeErr
+}
+
+func safeRelativePath(rawURL, fallback string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	p := strings.TrimPrefix(u.EscapedPath(), "/user_uploads/")
+	if p == "" || strings.Contains(p, "..") {
+		p = fallback
+	}
+	p, err = url.PathUnescape(p)
+	if err != nil {
+		return "", err
+	}
+	p = filepath.Clean(filepath.FromSlash(p))
+	if p == "." || p == string(os.PathSeparator) || strings.HasPrefix(p, "..") || filepath.IsAbs(p) {
+		return "", fmt.Errorf("unsafe attachment path %q", rawURL)
+	}
+	return p, nil
+}

--- a/internal/media/cache_test.go
+++ b/internal/media/cache_test.go
@@ -1,0 +1,84 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/FtlC-ian/zulcrawl/internal/store"
+	"github.com/FtlC-ian/zulcrawl/internal/zulip"
+)
+
+func TestFetchPendingDefaultsToAllPendingAttachments(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := st.UpsertOrganization(ctx, 1, "https://example.com", "Example"); err != nil {
+		t.Fatalf("UpsertOrganization: %v", err)
+	}
+	if err := st.UpsertStream(ctx, store.Stream{ID: 10, OrgID: 1, Name: "general"}); err != nil {
+		t.Fatalf("UpsertStream: %v", err)
+	}
+	if err := st.UpsertUser(ctx, store.User{ID: 20, OrgID: 1, FullName: "Sender"}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	for i := int64(1); i <= 105; i++ {
+		path := fmt.Sprintf("/user_uploads/a/file%03d.txt", i)
+		msg := store.Message{
+			ID:            1000 + i,
+			OrgID:         1,
+			StreamID:      10,
+			TopicID:       topicID,
+			SenderID:      20,
+			Content:       "file",
+			ContentText:   "file",
+			Timestamp:     "2026-01-02T03:04:05Z",
+			HasAttachment: true,
+			Attachments: []store.Attachment{{
+				URL:      path,
+				FileName: filepath.Base(path),
+			}},
+		}
+		if err := st.UpsertMessage(ctx, msg); err != nil {
+			t.Fatalf("UpsertMessage %d: %v", i, err)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.URL.Path) < len("/user_uploads/") || r.URL.Path[:len("/user_uploads/")] != "/user_uploads/" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = fmt.Fprintf(w, "body for %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	api := zulip.NewClient(srv.URL, "test@example.com", "testkey")
+	res, err := FetchPending(ctx, st, api, FetchOptions{CacheDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("FetchPending: %v", err)
+	}
+	if res.Fetched != 105 || res.Skipped != 0 || res.Failed != 0 {
+		t.Fatalf("FetchPending result = %+v, want 105 fetched", res)
+	}
+	rows, err := st.ListAttachments(ctx, store.AttachmentFilter{Status: StatusFetched})
+	if err != nil {
+		t.Fatalf("ListAttachments fetched: %v", err)
+	}
+	if len(rows) != 105 {
+		t.Fatalf("fetched rows = %d, want 105", len(rows))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1340,9 +1340,6 @@ type AttachmentFilter struct {
 
 func (s *Store) ListAttachments(ctx context.Context, f AttachmentFilter) ([]AttachmentRow, error) {
 	limit := f.Limit
-	if limit <= 0 {
-		limit = 100
-	}
 	q := `
 SELECT a.id, a.message_id, st.name, t.name, COALESCE(u.full_name,''), a.url,
        COALESCE(a.file_name,''), COALESCE(a.title,''), COALESCE(a.content_type,''), a.timestamp,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -117,6 +117,12 @@ CREATE TABLE IF NOT EXISTS message_attachments (
     text_content TEXT,
     indexed INTEGER DEFAULT 0,
     timestamp TEXT NOT NULL,
+    media_path TEXT,
+    media_status TEXT,
+    media_fetched_at TEXT,
+    media_content_type TEXT,
+    media_bytes INTEGER,
+    media_error TEXT,
     UNIQUE(message_id, url)
 );
 
@@ -158,6 +164,7 @@ CREATE INDEX IF NOT EXISTS idx_mentions_timestamp ON message_mentions(timestamp)
 CREATE INDEX IF NOT EXISTS idx_attachments_message ON message_attachments(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_stream_topic ON message_attachments(stream_id, topic_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_timestamp ON message_attachments(timestamp);
+CREATE INDEX IF NOT EXISTS idx_attachments_media_status ON message_attachments(media_status);
 CREATE INDEX IF NOT EXISTS idx_topics_stream ON topics(stream_id);
 CREATE INDEX IF NOT EXISTS idx_topics_resolved ON topics(resolved);
 
@@ -194,12 +201,42 @@ END;
 	if _, err := s.db.ExecContext(ctx, schema); err != nil {
 		return err
 	}
+	if err := s.migrateAttachmentMediaColumns(ctx); err != nil {
+		return err
+	}
 	if ftsMigrated {
 		if err := s.ReindexFTS(ctx); err != nil {
 			return err
 		}
 	}
 	return s.InitEmbeddingSchema(ctx)
+}
+
+func (s *Store) migrateAttachmentMediaColumns(ctx context.Context) error {
+	cols := []string{
+		"media_path TEXT",
+		"media_status TEXT",
+		"media_fetched_at TEXT",
+		"media_content_type TEXT",
+		"media_bytes INTEGER",
+		"media_error TEXT",
+	}
+	for _, col := range cols {
+		parts := strings.Fields(col)
+		name := parts[0]
+		var existing string
+		err := s.db.QueryRowContext(ctx, `SELECT name FROM pragma_table_info('message_attachments') WHERE name = ?`, name).Scan(&existing)
+		if err == nil {
+			continue
+		}
+		if err != sql.ErrNoRows {
+			return err
+		}
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE message_attachments ADD COLUMN `+col); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) prepareFTSMigration(ctx context.Context) (bool, error) {
@@ -619,11 +656,11 @@ type SearchHit struct {
 
 // TopicSearchHit is a single result from a topic-level search.
 type TopicSearchHit struct {
-	TopicID      int64
-	StreamName   string
-	TopicName    string
-	Resolved     bool
-	MessageCount int64
+	TopicID        int64
+	StreamName     string
+	TopicName      string
+	Resolved       bool
+	MessageCount   int64
 	LastMessageAt  string
 	FirstMessageAt string
 	// BestSnippet is a representative snippet from the best-matching message.
@@ -1272,4 +1309,104 @@ func (s *Store) EnsureStreamByName(ctx context.Context, orgID int64, streamID in
 		return fmt.Errorf("stream id missing")
 	}
 	return s.UpsertStream(ctx, Stream{ID: streamID, OrgID: orgID, Name: name})
+}
+
+// AttachmentRow is a locally indexed Zulip upload and its optional media-cache metadata.
+type AttachmentRow struct {
+	ID               int64
+	MessageID        int64
+	StreamName       string
+	TopicName        string
+	SenderName       string
+	URL              string
+	FileName         string
+	Title            string
+	ContentType      string
+	Timestamp        string
+	MediaPath        string
+	MediaStatus      string
+	MediaFetchedAt   string
+	MediaContentType string
+	MediaBytes       int64
+	MediaError       string
+}
+
+type AttachmentFilter struct {
+	Stream string
+	Topic  string
+	Status string // pending, fetched, error, or empty for all
+	Limit  int
+}
+
+func (s *Store) ListAttachments(ctx context.Context, f AttachmentFilter) ([]AttachmentRow, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	q := `
+SELECT a.id, a.message_id, st.name, t.name, COALESCE(u.full_name,''), a.url,
+       COALESCE(a.file_name,''), COALESCE(a.title,''), COALESCE(a.content_type,''), a.timestamp,
+       COALESCE(a.media_path,''), COALESCE(a.media_status,''), COALESCE(a.media_fetched_at,''),
+       COALESCE(a.media_content_type,''), COALESCE(a.media_bytes,0), COALESCE(a.media_error,'')
+FROM message_attachments a
+JOIN messages m ON m.id = a.message_id
+JOIN streams st ON st.id = a.stream_id
+JOIN topics t ON t.id = a.topic_id
+LEFT JOIN users u ON u.id = m.sender_id
+WHERE 1=1`
+	args := []any{}
+	if f.Stream != "" {
+		q += " AND st.name = ?"
+		args = append(args, f.Stream)
+	}
+	if f.Topic != "" {
+		q += " AND t.name = ?"
+		args = append(args, f.Topic)
+	}
+	switch f.Status {
+	case "pending":
+		q += " AND (a.media_status IS NULL OR a.media_status = '' OR a.media_status = 'error')"
+	case "fetched", "error":
+		q += " AND a.media_status = ?"
+		args = append(args, f.Status)
+	case "", "all":
+	default:
+		return nil, fmt.Errorf("unknown attachment status %q", f.Status)
+	}
+	q += " ORDER BY a.timestamp DESC, a.id DESC"
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AttachmentRow
+	for rows.Next() {
+		var r AttachmentRow
+		if err := rows.Scan(&r.ID, &r.MessageID, &r.StreamName, &r.TopicName, &r.SenderName, &r.URL, &r.FileName, &r.Title, &r.ContentType, &r.Timestamp, &r.MediaPath, &r.MediaStatus, &r.MediaFetchedAt, &r.MediaContentType, &r.MediaBytes, &r.MediaError); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+type AttachmentMediaUpdate struct {
+	Path        string
+	Status      string
+	FetchedAt   string
+	ContentType string
+	Bytes       int64
+	Error       string
+}
+
+func (s *Store) UpdateAttachmentMedia(ctx context.Context, id int64, u AttachmentMediaUpdate) error {
+	_, err := s.db.ExecContext(ctx, `
+UPDATE message_attachments
+SET media_path = ?, media_status = ?, media_fetched_at = ?, media_content_type = ?, media_bytes = ?, media_error = ?
+WHERE id = ?`, nullIfEmpty(u.Path), nullIfEmpty(u.Status), nullIfEmpty(u.FetchedAt), nullIfEmpty(u.ContentType), u.Bytes, nullIfEmpty(u.Error), id)
+	return err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,7 +37,7 @@ func (s *Store) InitSchema(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	schema := `
+	schemaCore := `
 CREATE TABLE IF NOT EXISTS organizations (
     id INTEGER PRIMARY KEY,
     url TEXT NOT NULL,
@@ -164,9 +164,17 @@ CREATE INDEX IF NOT EXISTS idx_mentions_timestamp ON message_mentions(timestamp)
 CREATE INDEX IF NOT EXISTS idx_attachments_message ON message_attachments(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_stream_topic ON message_attachments(stream_id, topic_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_timestamp ON message_attachments(timestamp);
-CREATE INDEX IF NOT EXISTS idx_attachments_media_status ON message_attachments(media_status);
 CREATE INDEX IF NOT EXISTS idx_topics_stream ON topics(stream_id);
 CREATE INDEX IF NOT EXISTS idx_topics_resolved ON topics(resolved);
+`
+	if _, err := s.db.ExecContext(ctx, schemaCore); err != nil {
+		return err
+	}
+	if err := s.migrateAttachmentMediaColumns(ctx); err != nil {
+		return err
+	}
+	schemaAfterMigrations := `
+CREATE INDEX IF NOT EXISTS idx_attachments_media_status ON message_attachments(media_status);
 
 CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
   INSERT INTO messages_fts(rowid, content_text, topic_name, sender_name, attachment_text)
@@ -198,10 +206,7 @@ CREATE TRIGGER IF NOT EXISTS topics_au AFTER UPDATE ON topics BEGIN
   INSERT INTO topics_fts(rowid, name) VALUES(new.id, new.name);
 END;
 `
-	if _, err := s.db.ExecContext(ctx, schema); err != nil {
-		return err
-	}
-	if err := s.migrateAttachmentMediaColumns(ctx); err != nil {
+	if _, err := s.db.ExecContext(ctx, schemaAfterMigrations); err != nil {
 		return err
 	}
 	if ftsMigrated {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -183,3 +183,53 @@ func TestEnsureMessageSenderInsertsNewUser(t *testing.T) {
 		t.Errorf("full_name = %q, want %q", fullName, "Ghost Bot")
 	}
 }
+
+func TestAttachmentMediaMetadata(t *testing.T) {
+	ctx := context.Background()
+	st, ctx := setupTestStore(t)
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	msg := Message{
+		ID:            200,
+		OrgID:         1,
+		StreamID:      10,
+		TopicID:       topicID,
+		SenderID:      20,
+		Content:       "file",
+		ContentText:   "file",
+		Timestamp:     "2026-01-02T03:04:05Z",
+		HasAttachment: true,
+		Attachments: []Attachment{{
+			URL:      "/user_uploads/a/report.txt",
+			FileName: "report.txt",
+		}},
+	}
+	if err := st.UpsertMessage(ctx, msg); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	rows, err := st.ListAttachments(ctx, AttachmentFilter{Status: "pending"})
+	if err != nil {
+		t.Fatalf("ListAttachments: %v", err)
+	}
+	if len(rows) != 1 || rows[0].MediaStatus != "" {
+		t.Fatalf("pending rows = %#v", rows)
+	}
+	if err := st.UpdateAttachmentMedia(ctx, rows[0].ID, AttachmentMediaUpdate{
+		Path:        "/tmp/report.txt",
+		Status:      "fetched",
+		FetchedAt:   "2026-01-02T04:00:00Z",
+		ContentType: "text/plain",
+		Bytes:       12,
+	}); err != nil {
+		t.Fatalf("UpdateAttachmentMedia: %v", err)
+	}
+	rows, err = st.ListAttachments(ctx, AttachmentFilter{Status: "fetched"})
+	if err != nil {
+		t.Fatalf("ListAttachments fetched: %v", err)
+	}
+	if len(rows) != 1 || rows[0].MediaPath != "/tmp/report.txt" || rows[0].MediaBytes != 12 {
+		t.Fatalf("fetched rows = %#v", rows)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 )
@@ -231,5 +232,49 @@ func TestAttachmentMediaMetadata(t *testing.T) {
 	}
 	if len(rows) != 1 || rows[0].MediaPath != "/tmp/report.txt" || rows[0].MediaBytes != 12 {
 		t.Fatalf("fetched rows = %#v", rows)
+	}
+}
+
+func TestListAttachmentsLimitSemantics(t *testing.T) {
+	st, ctx := setupTestStore(t)
+	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
+	if err != nil {
+		t.Fatalf("GetOrCreateTopic: %v", err)
+	}
+	for i := int64(1); i <= 105; i++ {
+		msg := Message{
+			ID:            1000 + i,
+			OrgID:         1,
+			StreamID:      10,
+			TopicID:       topicID,
+			SenderID:      20,
+			Content:       "file",
+			ContentText:   "file",
+			Timestamp:     "2026-01-02T03:04:05Z",
+			HasAttachment: true,
+			Attachments: []Attachment{{
+				URL:      fmt.Sprintf("/user_uploads/a/file%03d.txt", i),
+				FileName: "file.txt",
+			}},
+		}
+		if err := st.UpsertMessage(ctx, msg); err != nil {
+			t.Fatalf("UpsertMessage %d: %v", i, err)
+		}
+	}
+
+	rows, err := st.ListAttachments(ctx, AttachmentFilter{Status: "pending"})
+	if err != nil {
+		t.Fatalf("ListAttachments unlimited: %v", err)
+	}
+	if len(rows) != 105 {
+		t.Fatalf("unlimited ListAttachments returned %d rows, want 105", len(rows))
+	}
+
+	rows, err = st.ListAttachments(ctx, AttachmentFilter{Status: "pending", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListAttachments limited: %v", err)
+	}
+	if len(rows) != 100 {
+		t.Fatalf("limited ListAttachments returned %d rows, want 100", len(rows))
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -185,8 +186,51 @@ func TestEnsureMessageSenderInsertsNewUser(t *testing.T) {
 	}
 }
 
-func TestAttachmentMediaMetadata(t *testing.T) {
+func TestInitSchemaMigratesAttachmentMediaColumnsBeforeIndex(t *testing.T) {
 	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+CREATE TABLE message_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id INTEGER NOT NULL,
+    org_id INTEGER NOT NULL,
+    stream_id INTEGER NOT NULL,
+    topic_id INTEGER NOT NULL,
+    url TEXT NOT NULL,
+    file_name TEXT,
+    title TEXT,
+    content_type TEXT,
+    text_content TEXT,
+    indexed INTEGER DEFAULT 0,
+    timestamp TEXT NOT NULL,
+    UNIQUE(message_id, url)
+);
+`)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("create old attachment table: %v", err)
+	}
+	_ = db.Close()
+
+	st, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer st.Close()
+	if err := st.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema should migrate old attachment schema before creating media index: %v", err)
+	}
+	var indexed string
+	if err := st.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_attachments_media_status'`).Scan(&indexed); err != nil {
+		t.Fatalf("media status index missing after migration: %v", err)
+	}
+}
+
+func TestAttachmentMediaMetadata(t *testing.T) {
 	st, ctx := setupTestStore(t)
 	topicID, err := st.GetOrCreateTopic(ctx, 1, 10, "triage")
 	if err != nil {

--- a/internal/zulip/client.go
+++ b/internal/zulip/client.go
@@ -1,6 +1,7 @@
 package zulip
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -55,16 +56,16 @@ type User struct {
 }
 
 type Message struct {
-	ID             int64           `json:"id"`
-	SenderID       int64           `json:"sender_id"`
-	SenderFullName string          `json:"sender_full_name"`
-	StreamID       int64           `json:"stream_id"`
-	Subject        string          `json:"subject"`
-	Topic          string          `json:"topic"`
-	Content        string          `json:"content"`
-	Timestamp      int64           `json:"timestamp"`
-	EditTimestamp  int64           `json:"edit_timestamp"`
-	Type           string          `json:"type"`
+	ID             int64  `json:"id"`
+	SenderID       int64  `json:"sender_id"`
+	SenderFullName string `json:"sender_full_name"`
+	StreamID       int64  `json:"stream_id"`
+	Subject        string `json:"subject"`
+	Topic          string `json:"topic"`
+	Content        string `json:"content"`
+	Timestamp      int64  `json:"timestamp"`
+	EditTimestamp  int64  `json:"edit_timestamp"`
+	Type           string `json:"type"`
 	// IsMe is true for /me action messages (Zulip field: is_me_message).
 	// This is distinct from Type=="private" which indicates a direct message.
 	IsMe      bool            `json:"is_me_message"`
@@ -90,6 +91,17 @@ type getUsersResp struct {
 }
 
 func (c *Client) do(ctx context.Context, method, path string, q url.Values, out any) error {
+	body, _, err := c.doRaw(ctx, method, path, q)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *Client) doRaw(ctx context.Context, method, path string, q url.Values) ([]byte, http.Header, error) {
 	u := c.baseURL + path
 	if len(q) > 0 {
 		u += "?" + q.Encode()
@@ -99,7 +111,7 @@ func (c *Client) do(ctx context.Context, method, path string, q url.Values, out 
 	for attempt := 0; attempt < 5; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, method, u, nil)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		req.SetBasicAuth(c.email, c.apiKey)
 
@@ -124,11 +136,7 @@ func (c *Client) do(ctx context.Context, method, path string, q url.Values, out 
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return fmt.Errorf("zulip api %s: status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
-		}
-
-		if err := json.Unmarshal(body, out); err != nil {
-			return fmt.Errorf("decode %s: %w", path, err)
+			return nil, nil, fmt.Errorf("zulip api %s: status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 
 		if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
@@ -136,12 +144,25 @@ func (c *Client) do(ctx context.Context, method, path string, q url.Values, out 
 				time.Sleep(1500 * time.Millisecond)
 			}
 		}
-		return nil
+		return body, resp.Header.Clone(), nil
 	}
 	if lastErr != nil {
-		return lastErr
+		return nil, nil, lastErr
 	}
-	return fmt.Errorf("zulip api %s failed after retries", path)
+	return nil, nil, fmt.Errorf("zulip api %s failed after retries", path)
+}
+
+// Download fetches a Zulip-hosted upload using the same basic auth credentials
+// as API calls. Only local /user_uploads/ paths are accepted.
+func (c *Client) Download(ctx context.Context, path string) (io.ReadCloser, string, error) {
+	if !strings.HasPrefix(path, "/user_uploads/") {
+		return nil, "", fmt.Errorf("not a Zulip upload path: %s", path)
+	}
+	body, hdr, err := c.doRaw(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	return io.NopCloser(bytes.NewReader(body)), hdr.Get("Content-Type"), nil
 }
 
 func (c *Client) ServerSettings(ctx context.Context) (*ServerSettings, error) {

--- a/internal/zulip/client.go
+++ b/internal/zulip/client.go
@@ -1,7 +1,6 @@
 package zulip
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -153,16 +152,66 @@ func (c *Client) doRaw(ctx context.Context, method, path string, q url.Values) (
 }
 
 // Download fetches a Zulip-hosted upload using the same basic auth credentials
-// as API calls. Only local /user_uploads/ paths are accepted.
+// as API calls. Only local /user_uploads/ paths are accepted. The response body
+// is streamed to the caller; callers must close it.
 func (c *Client) Download(ctx context.Context, path string) (io.ReadCloser, string, error) {
-	if !strings.HasPrefix(path, "/user_uploads/") {
-		return nil, "", fmt.Errorf("not a Zulip upload path: %s", path)
-	}
-	body, hdr, err := c.doRaw(ctx, http.MethodGet, path, nil)
+	resp, err := c.downloadResponse(ctx, path)
 	if err != nil {
 		return nil, "", err
 	}
-	return io.NopCloser(bytes.NewReader(body)), hdr.Get("Content-Type"), nil
+	return resp.Body, resp.Header.Get("Content-Type"), nil
+}
+
+func (c *Client) downloadResponse(ctx context.Context, path string) (*http.Response, error) {
+	if !strings.HasPrefix(path, "/user_uploads/") {
+		return nil, fmt.Errorf("not a Zulip upload path: %s", path)
+	}
+	u := c.baseURL + path
+
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.SetBasicAuth(c.email, c.apiKey)
+
+		resp, err := c.hc.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt+1) * time.Second)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			wait := 2 * time.Second
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if n, err := strconv.Atoi(ra); err == nil {
+					wait = time.Duration(n) * time.Second
+				}
+			}
+			time.Sleep(wait)
+			continue
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("zulip download %s: status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		if rem := resp.Header.Get("X-RateLimit-Remaining"); rem != "" {
+			if n, err := strconv.Atoi(rem); err == nil && n < 5 {
+				time.Sleep(1500 * time.Millisecond)
+			}
+		}
+		return resp, nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("zulip download %s failed after retries", path)
 }
 
 func (c *Client) ServerSettings(ctx context.Context) (*ServerSettings, error) {

--- a/internal/zulip/client_test.go
+++ b/internal/zulip/client_test.go
@@ -1,0 +1,84 @@
+package zulip
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDownloadStreamsBody(t *testing.T) {
+	continueBody := make(chan struct{})
+	handlerStarted := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user_uploads/1/large.bin" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if user, pass, ok := r.BasicAuth(); !ok || user != "test@example.com" || pass != "testkey" {
+			t.Fatalf("missing basic auth: %q %q %v", user, pass, ok)
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte("first"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		close(handlerStarted)
+		<-continueBody
+		_, _ = w.Write([]byte("second"))
+	}))
+	defer srv.Close()
+
+	api := NewClient(srv.URL, "test@example.com", "testkey")
+	type result struct {
+		body        io.ReadCloser
+		contentType string
+		err         error
+	}
+	done := make(chan result, 1)
+	go func() {
+		body, contentType, err := api.Download(context.Background(), "/user_uploads/1/large.bin")
+		done <- result{body: body, contentType: contentType, err: err}
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not start streaming response")
+	}
+
+	var res result
+	select {
+	case res = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Download waited for the full response body instead of returning a stream")
+	}
+	if res.err != nil {
+		t.Fatalf("Download: %v", res.err)
+	}
+	defer res.body.Close()
+	if res.contentType != "application/octet-stream" {
+		t.Fatalf("contentType = %q", res.contentType)
+	}
+
+	close(continueBody)
+	got, err := io.ReadAll(res.body)
+	if err != nil {
+		t.Fatalf("ReadAll streamed body: %v", err)
+	}
+	if string(got) != "firstsecond" {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestDownloadRejectsNonUploadPath(t *testing.T) {
+	api := NewClient("https://zulip.example.com", "test@example.com", "testkey")
+	body, _, err := api.Download(context.Background(), "/api/v1/messages")
+	if err == nil {
+		if body != nil {
+			_ = body.Close()
+		}
+		t.Fatal("Download accepted non-upload path")
+	}
+}


### PR DESCRIPTION
## Summary
- add local-only media cache config and schema metadata for Zulip /user_uploads attachments
- add `attachments` listing and `attachments fetch` download command using existing Zulip auth
- add `sync --with-media` to cache indexed uploads after sync
- document media-cache behavior and privacy boundary

Fixes #18.

## Tests
- `go test ./...`
- `go test -race ./...`