### PR TITLE
feat: add local digest analytics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Vector-embedding provider integration is deferred to a future chunk (issue #9).
 `zulcrawl digest` summarizes a bounded slice of the local SQLite archive without
 hitting the Zulip API or any remote summarization service. It groups matching
 messages by topic and reports counts, first/last timestamps, participants, and
-a latest-message preview.
+a latest-message preview. It also highlights mention-heavy and attachment-heavy
+topics using the local `message_mentions` and `message_attachments` indexes.
 
 `--stream` and `--since` are required so digest runs stay intentionally scoped.
 
@@ -206,7 +207,17 @@ Text output format:
 #stream > topic (N messages, YYYY-MM-DD HH:MM to YYYY-MM-DD HH:MM)
   participants: Alice, Bob
   latest: latest message preview
+
+Mention-heavy topics:
+  #stream > topic (N mentions, last YYYY-MM-DD HH:MM)
+
+Attachment-heavy topics:
+  #stream > topic (N attachments, last YYYY-MM-DD HH:MM)
 ```
+
+JSON output is self-contained: the top-level object includes `stream`, `topics`,
+`mention_heavy_topics`, and `attachment_heavy_topics`; each topic row also
+includes its `stream`.
 
 ## messages command
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `stats`
   - `sql`
   - `messages` — direct archive slice queries (see below)
+  - `digest` — local-only topic activity digest (see below)
   - `attachments` / `attachments fetch` — list indexed uploads and cache Zulip media locally
   - `backfill-indexes` — rebuild mention/attachment indexes for existing messages
   - `embeddings backfill` — build/update Ollama topic embeddings (disabled by default)
@@ -125,6 +126,10 @@ zulcrawl topics search "database migration"
 zulcrawl topics search --stream engineering "deploy script"
 zulcrawl topics search --unresolved --limit 10 "onboarding"
 
+# Local topic digest
+zulcrawl digest --stream engineering --since 2026-05-01
+zulcrawl digest --stream engineering --since 2026-05-01 --until 2026-05-15 --json
+
 # Stats
 zulcrawl stats
 
@@ -166,6 +171,41 @@ Vector-embedding provider integration is deferred to a future chunk (issue #9).
 ```
 #stream > topic name [resolved] (N msgs, last YYYY-MM-DD)
   …best matching message snippet…
+```
+
+## digest command
+
+`zulcrawl digest` summarizes a bounded slice of the local SQLite archive without
+hitting the Zulip API or any remote summarization service. It groups matching
+messages by topic and reports counts, first/last timestamps, participants, and
+a latest-message preview.
+
+`--stream` and `--since` are required so digest runs stay intentionally scoped.
+
+**Flags**
+
+| Flag | Description |
+|------|-------------|
+| `--stream NAME` | Stream name to summarize (required) |
+| `--since DATE` | Include messages at or after this time (RFC3339 or `YYYY-MM-DD`; required) |
+| `--until DATE` | Include messages at or before this time (RFC3339 or `YYYY-MM-DD`) |
+| `--limit N` | Maximum topics to return (default 20) |
+| `--json` | Emit machine-readable JSON instead of text |
+
+**Examples**
+
+```bash
+zulcrawl digest --stream engineering --since 2026-05-01
+zulcrawl digest --stream support --since 2026-05-01T00:00:00Z --until 2026-05-15T23:59:59Z --limit 10
+zulcrawl digest --stream engineering --since 2026-05-01 --json
+```
+
+Text output format:
+
+```
+#stream > topic (N messages, YYYY-MM-DD HH:MM to YYYY-MM-DD HH:MM)
+  participants: Alice, Bob
+  latest: latest message preview
 ```
 
 ## messages command

--- a/internal/cli/messages_test.go
+++ b/internal/cli/messages_test.go
@@ -54,7 +54,7 @@ func setupCLITest(t *testing.T) string {
 	}
 	now := time.Now().UTC()
 	for i, content := range []string{"deployed v1", "deployed v2", "deployed v3"} {
-		if err := st.UpsertMessage(ctx, store.Message{
+		msg := store.Message{
 			ID:          int64(100 + i),
 			OrgID:       1,
 			StreamID:    1,
@@ -63,7 +63,18 @@ func setupCLITest(t *testing.T) string {
 			Content:     content,
 			ContentText: content,
 			Timestamp:   now.Add(time.Duration(-3+i) * 24 * time.Hour).Format(time.RFC3339),
-		}); err != nil {
+		}
+		if i < 2 {
+			msg.Mentions = []store.Mention{{UserID: 10, Name: "Alice", Kind: "user"}}
+		}
+		if i == 2 {
+			msg.HasAttachment = true
+			msg.Attachments = []store.Attachment{
+				{URL: "/user_uploads/1/deploy-log.txt", FileName: "deploy-log.txt", Text: "deploy log", Indexed: true},
+				{URL: "/user_uploads/1/screenshot.png", FileName: "screenshot.png"},
+			}
+		}
+		if err := st.UpsertMessage(ctx, msg); err != nil {
 			t.Fatalf("UpsertMessage: %v", err)
 		}
 	}
@@ -266,7 +277,7 @@ func TestDigestCmd_TextOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nOutput: %s", err, out)
 	}
-	for _, want := range []string{"#general > deploys", "3 messages", "participants: Alice", "latest: deployed v3", "(1 topics)"} {
+	for _, want := range []string{"#general > deploys", "3 messages", "participants: Alice", "latest: deployed v3", "Mention-heavy topics:", "2 mentions", "Attachment-heavy topics:", "2 attachments", "(1 topics)"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in output, got: %s", want, out)
 		}
@@ -280,8 +291,10 @@ func TestDigestCmd_JSONOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, `"topic": "deploys"`) || !strings.Contains(out, `"messages": 3`) {
-		t.Errorf("expected JSON digest row, got: %s", out)
+	for _, want := range []string{`"stream": "general"`, `"topics": [`, `"topic": "deploys"`, `"messages": 3`, `"mention_heavy_topics": [`, `"count": 2`, `"attachment_heavy_topics": [`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %s in JSON digest, got: %s", want, out)
+		}
 	}
 }
 

--- a/internal/cli/messages_test.go
+++ b/internal/cli/messages_test.go
@@ -243,3 +243,69 @@ func TestMessagesCommandRejectsNegativeCounts(t *testing.T) {
 		}
 	}
 }
+
+func runDigest(t *testing.T, cfgPath string, args ...string) (string, error) {
+	t.Helper()
+	root := cli.NewRootCmd()
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	fullArgs := append([]string{"--config", cfgPath, "digest"}, args...)
+	root.SetArgs(fullArgs)
+
+	err := root.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+func TestDigestCmd_TextOutput(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	since := time.Now().UTC().Add(-8 * 24 * time.Hour).Format("2006-01-02")
+	out, err := runDigest(t, cfgPath, "--stream", "general", "--since", since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nOutput: %s", err, out)
+	}
+	for _, want := range []string{"#general > deploys", "3 messages", "participants: Alice", "latest: deployed v3", "(1 topics)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}
+
+func TestDigestCmd_JSONOutput(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	since := time.Now().UTC().Add(-8 * 24 * time.Hour).Format(time.RFC3339)
+	out, err := runDigest(t, cfgPath, "--stream", "general", "--since", since, "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, `"topic": "deploys"`) || !strings.Contains(out, `"messages": 3`) {
+		t.Errorf("expected JSON digest row, got: %s", out)
+	}
+}
+
+func TestDigestCmd_RequiresStreamAndSince(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	if _, err := runDigest(t, cfgPath, "--since", "2026-01-01"); err == nil {
+		t.Fatal("expected missing --stream error")
+	}
+	if _, err := runDigest(t, cfgPath, "--stream", "general"); err == nil {
+		t.Fatal("expected missing --since error")
+	}
+}
+
+func TestDigestCmd_UntilAndLimit(t *testing.T) {
+	cfgPath := setupCLITest(t)
+	out, err := runDigest(t, cfgPath,
+		"--stream", "general",
+		"--since", time.Now().UTC().Add(-8*24*time.Hour).Format("2006-01-02"),
+		"--until", time.Now().UTC().Add(-2*24*time.Hour).Format(time.RFC3339),
+		"--limit", "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "2 messages") {
+		t.Errorf("expected until filter to leave 2 messages, got: %s", out)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(statsCmd(loadCfg))
 	root.AddCommand(sqlCmd(loadCfg))
 	root.AddCommand(messagesCmd(loadCfg))
+	root.AddCommand(digestCmd(loadCfg))
 	root.AddCommand(attachmentsCmd(loadCfg))
 	root.AddCommand(backfillIndexesCmd(loadCfg))
 	root.AddCommand(embeddingsCmd(loadCfg))
@@ -621,6 +622,133 @@ The default safety limit is 200 messages; use --limit or --all to override.`,
 	cmd.Flags().IntVar(&limit, "limit", 200, "maximum messages to return (default 200)")
 	cmd.Flags().BoolVar(&all, "all", false, "remove safety limit and return all matching messages")
 	return cmd
+}
+
+type digestJSONRow struct {
+	Topic        string   `json:"topic"`
+	Messages     int      `json:"messages"`
+	FirstAt      string   `json:"first_at"`
+	LastAt       string   `json:"last_at"`
+	Participants []string `json:"participants"`
+	Preview      string   `json:"preview"`
+}
+
+func digestCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
+	var stream, since, until string
+	var limit int
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "digest",
+		Short: "Summarize local archive activity by topic",
+		Long: `Summarize local SQLite archive activity by topic without calling Zulip.
+
+The digest is intentionally local-only: it reads the mirrored SQLite database,
+groups messages by topic, and prints message counts, date range, participants,
+and a latest-message preview. Use --stream and --since to keep the slice bounded.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if stream == "" {
+				return fmt.Errorf("--stream is required")
+			}
+			if since == "" {
+				return fmt.Errorf("--since is required")
+			}
+			if limit <= 0 {
+				return fmt.Errorf("--limit must be positive")
+			}
+
+			normSince, err := normalizeCLITime("since", since, false)
+			if err != nil {
+				return err
+			}
+			normUntil := ""
+			if until != "" {
+				normUntil, err = normalizeCLITime("until", until, true)
+				if err != nil {
+					return err
+				}
+			}
+
+			cfg, err := loadCfg()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open(cfg.DBPath())
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+
+			rows, err := st.Digest(cmd.Context(), store.DigestFilter{
+				Stream: stream,
+				Since:  normSince,
+				Until:  normUntil,
+				Limit:  limit,
+			})
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				out := make([]digestJSONRow, 0, len(rows))
+				for _, r := range rows {
+					out = append(out, digestJSONRow{
+						Topic:        r.TopicName,
+						Messages:     r.MessageCount,
+						FirstAt:      r.FirstMessageAt,
+						LastAt:       r.LastMessageAt,
+						Participants: r.Participants,
+						Preview:      r.Preview,
+					})
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No digest entries found.")
+				return nil
+			}
+			for _, r := range rows {
+				fmt.Fprintf(cmd.OutOrStdout(), "#%s > %s (%d messages, %s to %s)\n",
+					r.StreamName, r.TopicName, r.MessageCount, formatDigestTime(r.FirstMessageAt), formatDigestTime(r.LastMessageAt))
+				if len(r.Participants) > 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "  participants: %s\n", strings.Join(r.Participants, ", "))
+				}
+				if r.Preview != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "  latest: %s\n", r.Preview)
+				}
+				fmt.Fprintln(cmd.OutOrStdout())
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "(%d topics)\n", len(rows))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&stream, "stream", "", "stream name (required)")
+	cmd.Flags().StringVar(&since, "since", "", "include messages at or after this time (RFC3339 or YYYY-MM-DD; required)")
+	cmd.Flags().StringVar(&until, "until", "", "include messages at or before this time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().IntVar(&limit, "limit", 20, "maximum topics to return")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON instead of text")
+	return cmd
+}
+
+func normalizeCLITime(flagName, val string, endOfDay bool) (string, error) {
+	if t, err := time.Parse(time.RFC3339, val); err == nil {
+		return t.UTC().Format(time.RFC3339), nil
+	}
+	if _, err := time.Parse("2006-01-02", val); err != nil {
+		return "", fmt.Errorf("--%s must be RFC3339 (2006-01-02T15:04:05Z) or YYYY-MM-DD, got %q", flagName, val)
+	}
+	if endOfDay {
+		return val + "T23:59:59Z", nil
+	}
+	return val + "T00:00:00Z", nil
+}
+
+func formatDigestTime(ts string) string {
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t.Format("2006-01-02 15:04")
+	}
+	return ts
 }
 
 func attachmentsCmd(loadCfg func() (*config.Config, error)) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -624,13 +624,28 @@ The default safety limit is 200 messages; use --limit or --all to override.`,
 	return cmd
 }
 
+type digestJSONOutput struct {
+	Stream                string                  `json:"stream"`
+	Topics                []digestJSONRow         `json:"topics"`
+	MentionHeavyTopics    []digestJSONTopicSignal `json:"mention_heavy_topics"`
+	AttachmentHeavyTopics []digestJSONTopicSignal `json:"attachment_heavy_topics"`
+}
+
 type digestJSONRow struct {
+	Stream       string   `json:"stream"`
 	Topic        string   `json:"topic"`
 	Messages     int      `json:"messages"`
 	FirstAt      string   `json:"first_at"`
 	LastAt       string   `json:"last_at"`
 	Participants []string `json:"participants"`
 	Preview      string   `json:"preview"`
+}
+
+type digestJSONTopicSignal struct {
+	Stream string `json:"stream"`
+	Topic  string `json:"topic"`
+	Count  int    `json:"count"`
+	LastAt string `json:"last_at"`
 }
 
 func digestCmd(loadCfg func() (*config.Config, error)) *cobra.Command {
@@ -679,19 +694,34 @@ and a latest-message preview. Use --stream and --since to keep the slice bounded
 			}
 			defer st.Close()
 
-			rows, err := st.Digest(cmd.Context(), store.DigestFilter{
+			filter := store.DigestFilter{
 				Stream: stream,
 				Since:  normSince,
 				Until:  normUntil,
 				Limit:  limit,
-			})
+			}
+			rows, err := st.Digest(cmd.Context(), filter)
+			if err != nil {
+				return err
+			}
+			mentionHeavy, err := st.DigestMentionHeavyTopics(cmd.Context(), filter)
+			if err != nil {
+				return err
+			}
+			attachmentHeavy, err := st.DigestAttachmentHeavyTopics(cmd.Context(), filter)
 			if err != nil {
 				return err
 			}
 			if jsonOut {
-				out := make([]digestJSONRow, 0, len(rows))
+				out := digestJSONOutput{
+					Stream:                stream,
+					Topics:                make([]digestJSONRow, 0, len(rows)),
+					MentionHeavyTopics:    digestJSONSignals(mentionHeavy),
+					AttachmentHeavyTopics: digestJSONSignals(attachmentHeavy),
+				}
 				for _, r := range rows {
-					out = append(out, digestJSONRow{
+					out.Topics = append(out.Topics, digestJSONRow{
+						Stream:       r.StreamName,
 						Topic:        r.TopicName,
 						Messages:     r.MessageCount,
 						FirstAt:      r.FirstMessageAt,
@@ -719,6 +749,8 @@ and a latest-message preview. Use --stream and --since to keep the slice bounded
 				}
 				fmt.Fprintln(cmd.OutOrStdout())
 			}
+			printDigestSignals(cmd, "Mention-heavy topics", mentionHeavy, "mentions")
+			printDigestSignals(cmd, "Attachment-heavy topics", attachmentHeavy, "attachments")
 			fmt.Fprintf(cmd.OutOrStdout(), "(%d topics)\n", len(rows))
 			return nil
 		},
@@ -729,6 +761,31 @@ and a latest-message preview. Use --stream and --since to keep the slice bounded
 	cmd.Flags().IntVar(&limit, "limit", 20, "maximum topics to return")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON instead of text")
 	return cmd
+}
+
+func digestJSONSignals(rows []store.DigestTopicSignal) []digestJSONTopicSignal {
+	out := make([]digestJSONTopicSignal, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, digestJSONTopicSignal{
+			Stream: r.StreamName,
+			Topic:  r.TopicName,
+			Count:  r.Count,
+			LastAt: r.LastAt,
+		})
+	}
+	return out
+}
+
+func printDigestSignals(cmd *cobra.Command, title string, rows []store.DigestTopicSignal, unit string) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", title)
+	for _, r := range rows {
+		fmt.Fprintf(cmd.OutOrStdout(), "  #%s > %s (%d %s, last %s)\n",
+			r.StreamName, r.TopicName, r.Count, unit, formatDigestTime(r.LastAt))
+	}
+	fmt.Fprintln(cmd.OutOrStdout())
 }
 
 func normalizeCLITime(flagName, val string, endOfDay bool) (string, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1153,6 +1153,110 @@ WHERE 1=1`
 	return out, rows.Err()
 }
 
+// DigestFilter specifies the local archive slice to summarize.
+type DigestFilter struct {
+	Stream string
+	Since  string
+	Until  string
+	Limit  int
+}
+
+// DigestRow summarizes activity for one topic in a local-only digest.
+type DigestRow struct {
+	StreamName     string
+	TopicName      string
+	MessageCount   int
+	FirstMessageAt string
+	LastMessageAt  string
+	Participants   []string
+	Preview        string
+}
+
+// Digest groups messages by topic for a stream/time slice. It only reads the
+// local SQLite mirror; no Zulip API calls or remote services are involved.
+func (s *Store) Digest(ctx context.Context, f DigestFilter) ([]DigestRow, error) {
+	if f.Stream == "" {
+		return nil, fmt.Errorf("stream is required")
+	}
+	if f.Since == "" {
+		return nil, fmt.Errorf("since is required")
+	}
+	if f.Limit <= 0 {
+		f.Limit = 20
+	}
+
+	q := `
+SELECT st.name, t.name, COUNT(*) AS message_count,
+       MIN(m.timestamp) AS first_message_at,
+       MAX(m.timestamp) AS last_message_at,
+       COALESCE((
+         SELECT group_concat(name, char(31))
+         FROM (
+           SELECT DISTINCT COALESCE(u2.full_name,'') AS name
+           FROM messages m2
+           JOIN users u2 ON u2.id = m2.sender_id
+           WHERE m2.topic_id = t.id
+             AND m2.timestamp >= ?`
+	args := []any{f.Since}
+	if f.Until != "" {
+		q += " AND m2.timestamp <= ?"
+		args = append(args, f.Until)
+	}
+	q += `
+             AND COALESCE(u2.full_name,'') <> ''
+           ORDER BY name
+         )
+       ), '') AS participants,
+       COALESCE((
+         SELECT m3.content_text
+         FROM messages m3
+         WHERE m3.topic_id = t.id
+           AND m3.timestamp >= ?`
+	args = append(args, f.Since)
+	if f.Until != "" {
+		q += " AND m3.timestamp <= ?"
+		args = append(args, f.Until)
+	}
+	q += `
+         ORDER BY m3.timestamp DESC, m3.id DESC
+         LIMIT 1
+       ), '') AS preview
+FROM messages m
+JOIN streams st ON st.id = m.stream_id
+JOIN topics t ON t.id = m.topic_id
+WHERE st.name = ?
+  AND m.timestamp >= ?`
+	args = append(args, f.Stream, f.Since)
+	if f.Until != "" {
+		q += " AND m.timestamp <= ?"
+		args = append(args, f.Until)
+	}
+	q += `
+GROUP BY st.name, t.id, t.name
+ORDER BY message_count DESC, last_message_at DESC, t.name ASC
+LIMIT ?`
+	args = append(args, f.Limit)
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []DigestRow
+	for rows.Next() {
+		var r DigestRow
+		var participants string
+		if err := rows.Scan(&r.StreamName, &r.TopicName, &r.MessageCount, &r.FirstMessageAt, &r.LastMessageAt, &participants, &r.Preview); err != nil {
+			return nil, err
+		}
+		if participants != "" {
+			r.Participants = strings.Split(participants, string(rune(31)))
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1172,6 +1172,15 @@ type DigestRow struct {
 	Preview        string
 }
 
+// DigestTopicSignal summarizes a topic that stands out for one indexed signal
+// in a local-only digest (for example mentions or attachments).
+type DigestTopicSignal struct {
+	StreamName string
+	TopicName  string
+	Count      int
+	LastAt     string
+}
+
 // Digest groups messages by topic for a stream/time slice. It only reads the
 // local SQLite mirror; no Zulip API calls or remote services are involved.
 func (s *Store) Digest(ctx context.Context, f DigestFilter) ([]DigestRow, error) {
@@ -1251,6 +1260,66 @@ LIMIT ?`
 		}
 		if participants != "" {
 			r.Participants = strings.Split(participants, string(rune(31)))
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// DigestMentionHeavyTopics returns topics in the digest slice with the most
+// indexed mentions. It only reads message_mentions from the local SQLite mirror.
+func (s *Store) DigestMentionHeavyTopics(ctx context.Context, f DigestFilter) ([]DigestTopicSignal, error) {
+	return s.digestTopicSignals(ctx, f, "message_mentions", "mention-heavy topics")
+}
+
+// DigestAttachmentHeavyTopics returns topics in the digest slice with the most
+// indexed attachments. It only reads message_attachments from the local SQLite mirror.
+func (s *Store) DigestAttachmentHeavyTopics(ctx context.Context, f DigestFilter) ([]DigestTopicSignal, error) {
+	return s.digestTopicSignals(ctx, f, "message_attachments", "attachment-heavy topics")
+}
+
+func (s *Store) digestTopicSignals(ctx context.Context, f DigestFilter, table, label string) ([]DigestTopicSignal, error) {
+	if f.Stream == "" {
+		return nil, fmt.Errorf("stream is required")
+	}
+	if f.Since == "" {
+		return nil, fmt.Errorf("since is required")
+	}
+	if f.Limit <= 0 {
+		f.Limit = 20
+	}
+	if table != "message_mentions" && table != "message_attachments" {
+		return nil, fmt.Errorf("unsupported digest signal table %q", table)
+	}
+
+	q := fmt.Sprintf(`
+SELECT st.name, t.name, COUNT(*) AS signal_count, MAX(x.timestamp) AS last_at
+FROM %s x
+JOIN streams st ON st.id = x.stream_id
+JOIN topics t ON t.id = x.topic_id
+WHERE st.name = ?
+  AND x.timestamp >= ?`, table)
+	args := []any{f.Stream, f.Since}
+	if f.Until != "" {
+		q += " AND x.timestamp <= ?"
+		args = append(args, f.Until)
+	}
+	q += `
+GROUP BY st.name, t.id, t.name
+ORDER BY signal_count DESC, last_at DESC, t.name ASC
+LIMIT ?`
+	args = append(args, f.Limit)
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("digest %s: %w", label, err)
+	}
+	defer rows.Close()
+	var out []DigestTopicSignal
+	for rows.Next() {
+		var r DigestTopicSignal
+		if err := rows.Scan(&r.StreamName, &r.TopicName, &r.Count, &r.LastAt); err != nil {
+			return nil, err
 		}
 		out = append(out, r)
 	}


### PR DESCRIPTION
Closes #20.

## Summary

Adds a local-only `zulcrawl digest` command for deterministic archive analytics from SQLite.

## What landed

- `zulcrawl digest --stream <name> --since <date> [--until <date>] [--limit N]`
- text output with active topic previews plus mention-heavy and attachment-heavy sections
- `--json` output with top-level `stream`, `topics`, `mention_heavy_topics`, and `attachment_heavy_topics`
- no Zulip/API/LLM calls; digest reads only from the local SQLite archive
- README docs and CLI/store tests

## Verification

- Debbie: `go test ./...` ✅
- Debbie: smoke-tested text and JSON output against local archive ✅
- Hawk review: APPROVED at `296274f` ✅
- Hawk verification: `go test ./internal/cli ./internal/store` and `go test ./...` ✅
